### PR TITLE
Fix deterministic tag order in filename generation

### DIFF
--- a/logic/renamer.py
+++ b/logic/renamer.py
@@ -18,7 +18,8 @@ class Renamer:
         counter = 1
         for item in self.items:
             orig_path = item.original_path
-            ordered_tags = list(item.tags)
+            # sort tags to ensure deterministic naming order
+            ordered_tags = sorted(item.tags)
             new_basename = item.build_new_name(self.project, counter, date_str, ordered_tags)
             dirpath = os.path.dirname(orig_path)
             candidate = os.path.join(dirpath, new_basename)


### PR DESCRIPTION
## Summary
- sort selected tags before generating new filenames

## Testing
- `python3 -m py_compile main.py ui/main_window.py logic/renamer.py logic/settings.py ui/components.py utils/file_utils.py old_photo_renamer.py`

------
https://chatgpt.com/codex/tasks/task_e_684ca6a7d02c83269b5fb60be14a20c7