### PR TITLE
Move configs to user directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,7 @@ A desktop application to rename photos and videos using project numbers, tags an
    ```bash
    python -m mic_renamer
    ```
+
+Configuration files are stored in the user specific configuration directory
+(e.g. `~/.config/mic-renamer` on Linux). Set the `RENAMER_CONFIG_DIR`
+environment variable to override this location.

--- a/mic_renamer/config/app_config.py
+++ b/mic_renamer/config/app_config.py
@@ -1,8 +1,40 @@
 import json
 import os
+import shutil
+from appdirs import user_config_dir
 
 PACKAGE_ROOT = os.path.dirname(os.path.dirname(__file__))
-CONFIG_FILE = os.path.join(PACKAGE_ROOT, "config", "app_settings.json")
+
+# Environment variable to override the configuration directory
+ENV_CONFIG_DIR = "RENAMER_CONFIG_DIR"
+
+
+def get_config_dir() -> str:
+    """Return the directory used to store user configuration."""
+    env_dir = os.environ.get(ENV_CONFIG_DIR)
+    if env_dir:
+        return env_dir
+    return user_config_dir("mic-renamer")
+
+
+# old config location inside the package directory (pre 1.1)
+OLD_CONFIG_DIR = os.path.join(PACKAGE_ROOT, "config")
+CONFIG_DIR = get_config_dir()
+CONFIG_FILE = os.path.join(CONFIG_DIR, "app_settings.json")
+
+
+def _migrate_legacy_config():
+    """Move configuration files from the old location if present."""
+    old_cfg = os.path.join(OLD_CONFIG_DIR, "app_settings.json")
+    if os.path.isfile(old_cfg) and not os.path.isfile(CONFIG_FILE):
+        os.makedirs(CONFIG_DIR, exist_ok=True)
+        shutil.move(old_cfg, CONFIG_FILE)
+
+    old_tags = os.path.join(OLD_CONFIG_DIR, "tags.json")
+    new_tags = os.path.join(CONFIG_DIR, "tags.json")
+    if os.path.isfile(old_tags) and not os.path.isfile(new_tags):
+        os.makedirs(CONFIG_DIR, exist_ok=True)
+        shutil.move(old_tags, new_tags)
 
 DEFAULT_CONFIG = {
     "accepted_extensions": [
@@ -18,6 +50,7 @@ def load_config():
     global _config
     if _config is not None:
         return _config
+    _migrate_legacy_config()
     data = {}
     if os.path.isfile(CONFIG_FILE):
         try:

--- a/mic_renamer/logic/tag_loader.py
+++ b/mic_renamer/logic/tag_loader.py
@@ -1,11 +1,11 @@
 import json
 import os
 
-PACKAGE_ROOT = os.path.dirname(os.path.dirname(__file__))
-DEFAULT_TAGS_FILE = os.path.join(PACKAGE_ROOT, "config", "tags.json")
+from ..config.app_config import get_config_dir, load_config
+
+DEFAULT_TAGS_FILE = os.path.join(get_config_dir(), "tags.json")
 
 try:
-    from ..config.app_config import load_config
     CONFIG_TAGS_FILE = load_config().get("tags_file")
 except Exception:
     CONFIG_TAGS_FILE = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 PySide6>=6.0.0
+appdirs>=1.4


### PR DESCRIPTION
## Summary
- support per-user config dir using `appdirs`
- migrate old configs if found
- adjust default tag file logic
- document the new location in README
- add dependency on `appdirs`

## Testing
- `python -m pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement PySide6)*

------
https://chatgpt.com/codex/tasks/task_e_684dc69267a883269e589514e1d2a3e0