### PR TITLE
Update translations for preview and progress dialogs

### DIFF
--- a/mic_renamer/ui/main_window.py
+++ b/mic_renamer/ui/main_window.py
@@ -596,7 +596,13 @@ class RenamerApp(QWidget):
 
     def execute_rename_with_progress(self, table_mapping):
         total = len(table_mapping)
-        progress = QProgressDialog("Renaming files...", "Abort", 0, total, self)
+        progress = QProgressDialog(
+            tr("renaming_files"),
+            tr("abort"),
+            0,
+            total,
+            self,
+        )
         progress.setWindowModality(Qt.WindowModal)
         progress.setMinimumDuration(200)
         progress.setValue(0)

--- a/mic_renamer/ui/preview_dialog.py
+++ b/mic_renamer/ui/preview_dialog.py
@@ -8,7 +8,10 @@ def show_preview(parent, mapping: list[tuple]):
     dlg.setWindowTitle(tr("preview_rename"))
     layout = QVBoxLayout(dlg)
     table = QTableWidget(len(mapping), 2)
-    table.setHorizontalHeaderLabels(["Current Name", "Proposed New Name"])
+    table.setHorizontalHeaderLabels([
+        tr("current_name"),
+        tr("proposed_new_name")
+    ])
     table.verticalHeader().setVisible(False)
     table.setEditTriggers(QTableWidget.NoEditTriggers)
     table.setSelectionMode(QTableWidget.NoSelection)

--- a/mic_renamer/utils/i18n.py
+++ b/mic_renamer/utils/i18n.py
@@ -29,6 +29,10 @@ TRANSLATIONS = {
         'accepted_ext_label': 'Accepted File Extensions (comma separated):',
         'language_label': 'Language:',
         'tags_label': 'Tags'
+        , 'current_name': 'Current Name'
+        , 'proposed_new_name': 'Proposed New Name'
+        , 'renaming_files': 'Renaming files...'
+        , 'abort': 'Abort'
     },
     'de': {
         'app_title': 'Foto/Video Umbenenner',
@@ -58,6 +62,10 @@ TRANSLATIONS = {
         'accepted_ext_label': 'Erlaubte Dateiendungen (durch Komma getrennt):',
         'language_label': 'Sprache:',
         'tags_label': 'Tags'
+        , 'current_name': 'Aktueller Name'
+        , 'proposed_new_name': 'Vorgeschlagener neuer Name'
+        , 'renaming_files': 'Dateien werden umbenannt...'
+        , 'abort': 'Abbrechen'
     }
 }
 


### PR DESCRIPTION
## Summary
- add translation keys for preview and progress dialog labels
- use `tr()` when showing preview headers
- use translated strings in progress dialog

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684dc68ed7148326a2f55c50c050ad16