### PR TITLE
fix tags file path persistence

### DIFF
--- a/mic_renamer/config/app_config.py
+++ b/mic_renamer/config/app_config.py
@@ -3,13 +3,15 @@ import os
 
 PACKAGE_ROOT = os.path.dirname(os.path.dirname(__file__))
 CONFIG_FILE = os.path.join(PACKAGE_ROOT, "config", "app_settings.json")
+DEFAULT_TAGS_FILE = os.path.join(PACKAGE_ROOT, "config", "tags.json")
 
 DEFAULT_CONFIG = {
     "accepted_extensions": [
         ".jpg", ".jpeg", ".png", ".gif", ".bmp",
         ".mp4", ".avi", ".mov", ".mkv"
     ],
-    "language": "en"
+    "language": "en",
+    "tags_file": DEFAULT_TAGS_FILE,
 }
 
 _config = None


### PR DESCRIPTION
## Summary
- save the tags file path in app config
- open SettingsDialog with the actual tags file location
- write back tag definitions to the same path

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684dc65cd2f08326bcb1d74f022f727f