### PR TITLE
UI theming and tag selector improvements

### DIFF
--- a/mic_renamer/__init__.py
+++ b/mic_renamer/__init__.py
@@ -1,11 +1,13 @@
 """Photo/Video renamer package."""
 
 from .config.app_config import load_config, save_config
+from .config.theme_config import load_theme
 from .utils.i18n import set_language
 
 # load configuration on import
 config = load_config()
 set_language(config.get("language", "en"))
+theme = load_theme()
 
-__all__ = ["config", "save_config"]
+__all__ = ["config", "theme", "save_config"]
 

--- a/mic_renamer/__main__.py
+++ b/mic_renamer/__main__.py
@@ -4,6 +4,8 @@ import sys
 from PySide6.QtWidgets import QApplication
 from PySide6.QtCore import Qt
 from .ui.main_window import RenamerApp
+from . import theme
+from .ui.theming import apply_theme
 
 if __name__ == '__main__':
     try:
@@ -12,6 +14,7 @@ if __name__ == '__main__':
     except Exception:
         pass
     app = QApplication(sys.argv)
+    apply_theme(app, theme)
     window = RenamerApp()
     window.resize(1000, 600)
     window.show()

--- a/mic_renamer/config/theme.yaml
+++ b/mic_renamer/config/theme.yaml
@@ -1,0 +1,4 @@
+theme:
+  primary_blue: "#0055AA"
+  background_white: "#F8F9FA"
+  accent_red: "#CC3333"

--- a/mic_renamer/config/theme_config.py
+++ b/mic_renamer/config/theme_config.py
@@ -1,0 +1,31 @@
+import os
+import yaml
+from .app_config import get_config_dir
+
+THEME_FILE = os.path.join(get_config_dir(), "theme.yaml")
+
+DEFAULT_THEME = {
+    "primary_blue": "#0055AA",
+    "background_white": "#F8F9FA",
+    "accent_red": "#CC3333",
+}
+
+_theme = None
+
+
+def load_theme() -> dict:
+    """Load theme colors from configuration file."""
+    global _theme
+    if _theme is not None:
+        return _theme
+    data = {}
+    if os.path.isfile(THEME_FILE):
+        try:
+            with open(THEME_FILE, "r", encoding="utf-8") as f:
+                loaded = yaml.safe_load(f) or {}
+                if isinstance(loaded, dict):
+                    data = loaded.get("theme", loaded)
+        except Exception:
+            data = {}
+    _theme = {**DEFAULT_THEME, **data}
+    return _theme

--- a/mic_renamer/ui/multi_select_combo.py
+++ b/mic_renamer/ui/multi_select_combo.py
@@ -1,0 +1,56 @@
+from PySide6.QtWidgets import QComboBox, QLineEdit
+from PySide6.QtGui import QStandardItemModel, QStandardItem
+from PySide6.QtCore import Qt, Signal
+
+
+class MultiSelectComboBox(QComboBox):
+    selectionChanged = Signal()
+
+    def __init__(self, options: dict[str, str], parent=None):
+        super().__init__(parent)
+        self.setEditable(True)
+        self.setInsertPolicy(QComboBox.NoInsert)
+        self._model = QStandardItemModel()
+        for code, desc in options.items():
+            item = QStandardItem(f"{code}: {desc}")
+            item.setData(code, Qt.UserRole)
+            item.setFlags(Qt.ItemIsEnabled | Qt.ItemIsUserCheckable)
+            item.setCheckState(Qt.Unchecked)
+            self._model.appendRow(item)
+        self.setModel(self._model)
+        self.view().pressed.connect(self.handle_item_pressed)
+        self.lineEdit().textEdited.connect(self.filter_items)
+        self._selected = set()
+
+    def handle_item_pressed(self, index):
+        item = self._model.itemFromIndex(index)
+        if item.checkState() == Qt.Checked:
+            item.setCheckState(Qt.Unchecked)
+            self._selected.discard(item.data(Qt.UserRole))
+        else:
+            item.setCheckState(Qt.Checked)
+            self._selected.add(item.data(Qt.UserRole))
+        self.update_display()
+        self.selectionChanged.emit()
+        # keep popup open
+        self.showPopup()
+
+    def filter_items(self, text: str):
+        for row in range(self._model.rowCount()):
+            item = self._model.item(row)
+            match = text.lower() in item.text().lower()
+            self.view().setRowHidden(row, not match)
+
+    def update_display(self):
+        self.lineEdit().setText(", ".join(sorted(self._selected)))
+
+    def selected_codes(self) -> set[str]:
+        return set(self._selected)
+
+    def set_selected_codes(self, codes: set[str]):
+        self._selected = set(codes)
+        for row in range(self._model.rowCount()):
+            item = self._model.item(row)
+            code = item.data(Qt.UserRole)
+            item.setCheckState(Qt.Checked if code in self._selected else Qt.Unchecked)
+        self.update_display()

--- a/mic_renamer/ui/theming.py
+++ b/mic_renamer/ui/theming.py
@@ -1,0 +1,14 @@
+from PySide6.QtWidgets import QApplication
+
+
+def apply_theme(app: QApplication, theme: dict):
+    """Apply basic theme colors to the QApplication."""
+    if not theme:
+        return
+    style_sheet = f"""
+    QToolBar {{ background-color: {theme['primary_blue']}; }}
+    QToolBar QToolButton {{ color: white; }}
+    QWidget#MainPanel {{ background-color: {theme['background_white']}; }}
+    QTableWidget {{ background-color: {theme['background_white']}; selection-background-color: #ADD8E6; }}
+    """
+    app.setStyleSheet(style_sheet)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 PySide6>=6.0.0
 appdirs>=1.4
+PyYAML>=6.0


### PR DESCRIPTION
## Summary
- support loading a theme config and expose `theme` variable
- use theme to style widgets via global style sheet
- add multi‑select combo box for tag editing
- embed project and suffix fields in toolbar
- add sample `theme.yaml`

## Testing
- `python3 -m pip install -r requirements.txt`
- `python3 -m compileall -q mic_renamer`

------
https://chatgpt.com/codex/tasks/task_e_684e9aad26208326b1a2bad0b778fcea