### PR TITLE
Improve toolbar and multi-file tagging

### DIFF
--- a/mic_renamer/ui/main_window.py
+++ b/mic_renamer/ui/main_window.py
@@ -120,6 +120,31 @@ class ImageViewer(QGraphicsView):
         self._rotation = (self._rotation + 90) % 360
         self.apply_transformations()
 
+class AspectRatioWidget(QWidget):
+    def __init__(self, aspect_ratio=16/9, parent=None):
+        super().__init__(parent)
+        self.aspect_ratio = aspect_ratio
+        self._widget = None
+
+    def setWidget(self, widget):
+        self._widget = widget
+        widget.setParent(self)
+
+    def resizeEvent(self, event):
+        if not self._widget:
+            return super().resizeEvent(event)
+        w = self.width()
+        h = self.height()
+        target_w = w
+        target_h = int(target_w / self.aspect_ratio)
+        if target_h > h:
+            target_h = h
+            target_w = int(target_h * self.aspect_ratio)
+        x = (w - target_w) // 2
+        y = (h - target_h) // 2
+        self._widget.setGeometry(x, y, target_w, target_h)
+        super().resizeEvent(event)
+
     def zoom_fit(self):
         if not self.pixmap_item:
             return
@@ -147,21 +172,22 @@ class ImageViewer(QGraphicsView):
 class DragDropTableWidget(QTableWidget):
     def __init__(self, parent=None):
         super().__init__(parent)
-        self.setColumnCount(3)
-        self.setHorizontalHeaderLabels(["Filename", "Tags", "Suffix"])
+        self.setColumnCount(4)
+        self.setHorizontalHeaderLabels(["", "Filename", "Tags", "Suffix"])
         header = self.horizontalHeader()
-        # Erste Spalte interaktiv, zweite interaktiv, dritte füllt Rest
-        header.setSectionResizeMode(0, QHeaderView.Interactive)
+        header.setSectionResizeMode(0, QHeaderView.ResizeToContents)
         header.setSectionResizeMode(1, QHeaderView.Interactive)
-        header.setSectionResizeMode(2, QHeaderView.Stretch)
+        header.setSectionResizeMode(2, QHeaderView.Interactive)
+        header.setSectionResizeMode(3, QHeaderView.Stretch)
         header.setStretchLastSection(True)
         header.sectionDoubleClicked.connect(self.on_header_double_clicked)
         self.setHorizontalScrollMode(QAbstractItemView.ScrollPerPixel)
         self.setAcceptDrops(True)
         self.setSelectionBehavior(QTableWidget.SelectRows)
-        self.setSelectionMode(QTableWidget.SingleSelection)
+        self.setSelectionMode(QTableWidget.ExtendedSelection)
         self.verticalHeader().setSectionResizeMode(QHeaderView.Fixed)
         self.verticalHeader().setDefaultSectionSize(24)
+        self.itemSelectionChanged.connect(self.sync_check_column)
 
     def on_header_double_clicked(self, index: int):
         header = self.horizontalHeader()
@@ -198,7 +224,7 @@ class DragDropTableWidget(QTableWidget):
         for path in paths:
             duplicate = False
             for row in range(self.rowCount()):
-                item = self.item(row, 0)
+                item = self.item(row, 1)
                 if item and item.data(Qt.UserRole) == path:
                     duplicate = True
                     break
@@ -206,19 +232,31 @@ class DragDropTableWidget(QTableWidget):
                 continue
             row = self.rowCount()
             self.insertRow(row)
+            check_item = QTableWidgetItem()
+            check_item.setFlags(Qt.ItemIsUserCheckable | Qt.ItemIsEnabled)
+            check_item.setCheckState(Qt.Unchecked)
             fname_item = QTableWidgetItem(os.path.basename(path))
             fname_item.setData(Qt.UserRole, path)
             fname_item.setBackground(QColor(30, 30, 30))
             fname_item.setForeground(QColor(220, 220, 220))
             tags_item = QTableWidgetItem("")
             suffix_item = QTableWidgetItem("")
-            tags_item.setToolTip("")    
+            tags_item.setToolTip("")
             suffix_item.setToolTip("")
-            self.setItem(row, 0, fname_item)
-            self.setItem(row, 1, tags_item)
-            self.setItem(row, 2, suffix_item)
+            self.setItem(row, 0, check_item)
+            self.setItem(row, 1, fname_item)
+            self.setItem(row, 2, tags_item)
+            self.setItem(row, 3, suffix_item)
         if self.rowCount() > 0 and not self.selectionModel().hasSelection():
             self.selectRow(0)
+
+    def sync_check_column(self):
+        selected = {idx.row() for idx in self.selectionModel().selectedRows()}
+        for row in range(self.rowCount()):
+            item = self.item(row, 0)
+            if not item:
+                continue
+            item.setCheckState(Qt.Checked if row in selected else Qt.Unchecked)
 
 class RenamerApp(QWidget):
     def __init__(self):
@@ -231,31 +269,15 @@ class RenamerApp(QWidget):
         self.setup_toolbar()
         main_layout.addWidget(self.toolbar)
 
-        # container for project/suffix controls and selected file label
+        # selected file label only
         controls_widget = QWidget()
         controls_layout = QVBoxLayout(controls_widget)
-        lbl_project = QLabel(tr("project_number_label"))
-        self.input_project = QLineEdit()
-        self.input_project.setPlaceholderText(tr("project_number_placeholder"))
-        controls_layout.addWidget(lbl_project)
-        controls_layout.addWidget(self.input_project)
-        controls_layout.addSpacing(10)
-
         lbl_selected = QLabel(tr("selected_file_label"))
         self.label_selected_file = QLabel("<none>")
         self.label_selected_file.setWordWrap(True)
         controls_layout.addWidget(lbl_selected)
         controls_layout.addWidget(self.label_selected_file)
         controls_layout.addSpacing(5)
-
-        lbl_suffix = QLabel(tr("custom_suffix_label"))
-        self.input_item_suffix = QLineEdit()
-        self.input_item_suffix.setPlaceholderText(tr("custom_suffix_placeholder"))
-        controls_layout.addWidget(lbl_suffix)
-        controls_layout.addWidget(self.input_item_suffix)
-        self.input_item_suffix.editingFinished.connect(self.save_current_item_settings)
-        controls_layout.addSpacing(10)
-
         main_layout.addWidget(controls_widget)
 
         grid = QGridLayout()
@@ -283,7 +305,9 @@ class RenamerApp(QWidget):
         viewer_layout.addLayout(viewer_toolbar)
 
         self.image_viewer = ImageViewer()
-        viewer_layout.addWidget(self.image_viewer, 5)
+        ar_widget = AspectRatioWidget()
+        ar_widget.setWidget(self.image_viewer)
+        viewer_layout.addWidget(ar_widget, 5)
 
         self.zoom_slider = QSlider(Qt.Horizontal)
         self.zoom_slider.setMinimum(10)
@@ -327,7 +351,7 @@ class RenamerApp(QWidget):
 
         # Initial deaktivieren
         self.set_item_controls_enabled(False)
-        self.table_widget.currentCellChanged.connect(self.on_table_selection_changed)
+        self.table_widget.itemSelectionChanged.connect(self.on_table_selection_changed)
 
         self.update_translations()
 
@@ -365,6 +389,22 @@ class RenamerApp(QWidget):
         act_settings.triggered.connect(self.open_settings)
         tb.addAction(act_settings)
 
+        tb.addSeparator()
+        self.lbl_project = QLabel(tr("project_number_label"))
+        self.input_project = QLineEdit()
+        self.input_project.setMaximumWidth(120)
+        self.input_project.setPlaceholderText(tr("project_number_placeholder"))
+        tb.addWidget(self.lbl_project)
+        tb.addWidget(self.input_project)
+
+        self.lbl_suffix = QLabel(tr("custom_suffix_label"))
+        self.input_item_suffix = QLineEdit()
+        self.input_item_suffix.setMaximumWidth(120)
+        self.input_item_suffix.setPlaceholderText(tr("custom_suffix_placeholder"))
+        self.input_item_suffix.editingFinished.connect(self.save_current_item_settings)
+        tb.addWidget(self.lbl_suffix)
+        tb.addWidget(self.input_item_suffix)
+
     def open_settings(self):
         dlg = SettingsDialog(self)
         if dlg.exec() == QDialog.Accepted:
@@ -385,6 +425,8 @@ class RenamerApp(QWidget):
             action.setText(tr(key))
             action.setToolTip(tr(key))
         # update form labels
+        self.lbl_project.setText(tr("project_number_label"))
+        self.lbl_suffix.setText(tr("custom_suffix_label"))
         self.input_project.setPlaceholderText(tr("project_number_placeholder"))
         self.input_item_suffix.setPlaceholderText(tr("custom_suffix_placeholder"))
 
@@ -409,57 +451,87 @@ class RenamerApp(QWidget):
             ]
             self.table_widget.add_paths(paths)
 
-    def on_table_selection_changed(self, row, col):
-        if row < 0 or row >= self.table_widget.rowCount():
+    def on_table_selection_changed(self):
+        rows = [idx.row() for idx in self.table_widget.selectionModel().selectedRows()]
+        if not rows:
             self.label_selected_file.setText("<none>")
             self.image_viewer.load_image("")
             self.zoom_slider.setValue(100)
             self.set_item_controls_enabled(False)
+            self.table_widget.sync_check_column()
             return
 
         self.set_item_controls_enabled(True)
-        item0 = self.table_widget.item(row, 0)
-        path = item0.data(Qt.UserRole)
-        self.label_selected_file.setText(os.path.basename(path))
-        settings: ItemSettings = item0.data(ROLE_SETTINGS)
-        if settings is None:
-            settings = ItemSettings(path)
-            item0.setData(ROLE_SETTINGS, settings)
+        settings_list = []
+        for r in rows:
+            item0 = self.table_widget.item(r, 1)
+            path = item0.data(Qt.UserRole)
+            st: ItemSettings = item0.data(ROLE_SETTINGS)
+            if st is None:
+                st = ItemSettings(path)
+                item0.setData(ROLE_SETTINGS, st)
+            settings_list.append(st)
+        first = settings_list[0]
+        if len(rows) == 1:
+            self.label_selected_file.setText(os.path.basename(first.original_path))
+        else:
+            self.label_selected_file.setText(f"{len(rows)} files selected")
 
         self.input_item_suffix.blockSignals(True)
-        self.input_item_suffix.setText(settings.suffix)
+        same_suffix = all(s.suffix == first.suffix for s in settings_list)
+        self.input_item_suffix.setText(first.suffix if same_suffix else "")
         self.input_item_suffix.blockSignals(False)
+
+        intersect = set(settings_list[0].tags)
+        union = set(settings_list[0].tags)
+        for st in settings_list[1:]:
+            intersect &= st.tags
+            union |= st.tags
         for code, cb in self.checkbox_map.items():
             cb.blockSignals(True)
-            cb.setChecked(code in settings.tags)
+            if code in intersect:
+                cb.setTristate(False)
+                cb.setCheckState(Qt.Checked)
+            elif code in union:
+                cb.setTristate(True)
+                cb.setCheckState(Qt.PartiallyChecked)
+            else:
+                cb.setTristate(False)
+                cb.setCheckState(Qt.Unchecked)
             cb.blockSignals(False)
 
-        # Preview laden mit Fit
-        self.load_preview(path)
-        self.update_row_background(row, settings)
+        self.load_preview(first.original_path)
+        self.table_widget.sync_check_column()
 
     def save_current_item_settings(self):
-        row = self.table_widget.currentRow()
-        if row < 0:
+        rows = [idx.row() for idx in self.table_widget.selectionModel().selectedRows()]
+        if not rows:
             return
-        item0 = self.table_widget.item(row, 0)
-        settings: ItemSettings = item0.data(ROLE_SETTINGS)
-        if not settings:
-            return
-        settings.suffix = self.input_item_suffix.text().strip()
-        selected = {code for code, cb in self.checkbox_map.items() if cb.isChecked()}
-        settings.tags = selected
-        tags_str = ",".join(sorted(settings.tags))
-        cell_tags = self.table_widget.item(row, 1)
-        cell_suffix = self.table_widget.item(row, 2)
-        cell_tags.setText(tags_str)
-        cell_tags.setToolTip(tags_str)
-        cell_suffix.setText(settings.suffix)
-        cell_suffix.setToolTip(settings.suffix)
-        self.update_row_background(row, settings)
+        checkbox_states = {code: cb.checkState() for code, cb in self.checkbox_map.items()}
+        suffix_text = self.input_item_suffix.text().strip()
+        for row in rows:
+            item0 = self.table_widget.item(row, 1)
+            settings: ItemSettings = item0.data(ROLE_SETTINGS)
+            if settings is None:
+                continue
+            settings.suffix = suffix_text
+            for code, state in checkbox_states.items():
+                if state == Qt.Checked:
+                    settings.tags.add(code)
+                elif state == Qt.Unchecked:
+                    settings.tags.discard(code)
+            tags_str = ",".join(sorted(settings.tags))
+            cell_tags = self.table_widget.item(row, 2)
+            cell_suffix = self.table_widget.item(row, 3)
+            cell_tags.setText(tags_str)
+            cell_tags.setToolTip(tags_str)
+            cell_suffix.setText(settings.suffix)
+            cell_suffix.setToolTip(settings.suffix)
+            self.update_row_background(row, settings)
+        self.table_widget.sync_check_column()
 
     def update_row_background(self, row: int, settings: ItemSettings):
-        for col in range(3):
+        for col in range(4):
             item = self.table_widget.item(row, col)
             if settings and (settings.suffix or settings.tags):
                 item.setBackground(QColor('#335533'))
@@ -520,7 +592,7 @@ class RenamerApp(QWidget):
         self.save_current_item_settings()
         items = []
         for row in range(n):
-            item0 = self.table_widget.item(row, 0)
+            item0 = self.table_widget.item(row, 1)
             path = item0.data(Qt.UserRole)
             settings: ItemSettings = item0.data(ROLE_SETTINGS)
             if settings is None:
@@ -540,7 +612,7 @@ class RenamerApp(QWidget):
         for settings, orig, new in mapping:
             new_name = os.path.basename(new)
             for row in range(self.table_widget.rowCount()):
-                item0 = self.table_widget.item(row, 0)
+                item0 = self.table_widget.item(row, 1)
                 if item0.data(Qt.UserRole) == orig:
                     table_mapping.append((row, orig, new_name, new))
                     break
@@ -581,7 +653,7 @@ class RenamerApp(QWidget):
             for settings, orig, new in mapping:
                 new_name = os.path.basename(new)
                 for row in range(self.table_widget.rowCount()):
-                    item0 = self.table_widget.item(row, 0)
+                    item0 = self.table_widget.item(row, 1)
                     if item0.data(Qt.UserRole) == orig:
                         table_mapping.append((row, orig, new_name, new))
                         break
@@ -608,7 +680,7 @@ class RenamerApp(QWidget):
                 new_abs = os.path.abspath(new_path)
                 if orig_abs != new_abs:
                     os.rename(orig, new_path)
-                    item0 = self.table_widget.item(row, 0)
+                    item0 = self.table_widget.item(row, 1)
                     item0.setText(os.path.basename(new_path))
                     item0.setData(Qt.UserRole, new_path)
             except Exception as e:


### PR DESCRIPTION
## Summary
- inline project number and suffix inputs in the toolbar
- keep preview panel 16:9 by using `AspectRatioWidget`
- expand file table with checkbox selection and multiselect logic
- support editing tags across multiple files

## Testing
- `python -m py_compile mic_renamer/ui/main_window.py`
- `python -m compileall -q mic_renamer`
- `python -m mic_renamer` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_684ea5e584e88326b625b09529a30cd9