### PR TITLE
Improve project number validation and tag panel

### DIFF
--- a/mic_renamer/__main__.py
+++ b/mic_renamer/__main__.py
@@ -13,7 +13,8 @@ if __name__ == '__main__':
         pass
     app = QApplication(sys.argv)
     window = RenamerApp()
-    window.resize(1000, 600)
+    window.setMinimumSize(1200, 800)
+    window.resize(1200, 800)
     window.show()
     sys.exit(app.exec())
 

--- a/mic_renamer/utils/i18n.py
+++ b/mic_renamer/utils/i18n.py
@@ -3,8 +3,8 @@ current_language = 'en'
 TRANSLATIONS = {
     'en': {
         'app_title': 'Photo/Video Renamer',
-        'project_number_label': 'Project Number:',
-        'project_number_placeholder': 'e.g. C230105',
+        'project_number_label': 'MC-No.:',
+        'project_number_placeholder': 'C123456',
         'selected_file_label': 'Selected File:',
         'custom_suffix_label': 'Custom Suffix for this file:',
         'custom_suffix_placeholder': 'e.g. DSC00138',
@@ -15,7 +15,7 @@ TRANSLATIONS = {
         'rename_all': 'Rename All',
         'clear_list': 'Clear List',
         'missing_project': 'Missing Project Number',
-        'missing_project_msg': 'Please enter project number.',
+        'missing_project_msg': 'Please enter MC-No. (C followed by 6 digits).',
         'no_files': 'No Files',
         'no_files_msg': 'No files to rename.',
         'confirm_rename': 'Confirm Rename',
@@ -26,6 +26,8 @@ TRANSLATIONS = {
         'done': 'Done',
         'rename_done': 'All files renamed.',
         'settings_title': 'Settings',
+        'show_tags': 'Show tags',
+        'hide_tags': 'Hide tags',
         'accepted_ext_label': 'Accepted File Extensions (comma separated):',
         'language_label': 'Language:',
         'tags_label': 'Tags'
@@ -36,8 +38,8 @@ TRANSLATIONS = {
     },
     'de': {
         'app_title': 'Foto/Video Umbenenner',
-        'project_number_label': 'Projektnummer:',
-        'project_number_placeholder': 'z.B. C230105',
+        'project_number_label': 'MC-Nr.:',
+        'project_number_placeholder': 'C123456',
         'selected_file_label': 'Ausgewählte Datei:',
         'custom_suffix_label': 'Individueller Suffix für diese Datei:',
         'custom_suffix_placeholder': 'z.B. DSC00138',
@@ -48,7 +50,7 @@ TRANSLATIONS = {
         'rename_all': 'Alle umbenennen',
         'clear_list': 'Liste leeren',
         'missing_project': 'Fehlende Projektnummer',
-        'missing_project_msg': 'Bitte Projektnummer eingeben.',
+        'missing_project_msg': 'Bitte MC-Nr. eingeben (C gefolgt von 6 Ziffern).',
         'no_files': 'Keine Dateien',
         'no_files_msg': 'Keine Dateien zum Umbenennen.',
         'confirm_rename': 'Umbenennen bestätigen',
@@ -61,7 +63,9 @@ TRANSLATIONS = {
         'settings_title': 'Einstellungen',
         'accepted_ext_label': 'Erlaubte Dateiendungen (durch Komma getrennt):',
         'language_label': 'Sprache:',
-        'tags_label': 'Tags'
+        'tags_label': 'Tags',
+        'show_tags': 'Tags anzeigen',
+        'hide_tags': 'Tags ausblenden'
         , 'current_name': 'Aktueller Name'
         , 'proposed_new_name': 'Vorgeschlagener neuer Name'
         , 'renaming_files': 'Dateien werden umbenannt...'


### PR DESCRIPTION
## Summary
- enforce `MC-No.`/`MC-Nr.` naming and input mask
- add translations for new labels and show/hide button
- rebuild tag checkboxes after editing settings
- add manual tag panel toggle and validate manually entered tags
- fix selection handling with shift-click
- use a gear icon for settings
- enlarge default window size

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684ec68afd888326ad807113e5af9001