### PR TITLE
Fix QStyle import for PySide6

### DIFF
--- a/mic_renamer/ui/main_window.py
+++ b/mic_renamer/ui/main_window.py
@@ -9,8 +9,9 @@ from PySide6.QtWidgets import (
     QToolBar,
     QFileDialog,
     QMessageBox,
+    QStyle,
 )
-from PySide6.QtGui import QAction, QIcon, QStyle
+from PySide6.QtGui import QAction, QIcon
 from PySide6.QtCore import Qt
 
 from .panels.image_preview import ImagePreviewPanel


### PR DESCRIPTION
## Summary
- adjust `main_window` imports to load `QStyle` from QtWidgets

## Testing
- `python -m py_compile mic_renamer/ui/main_window.py`
- `python -m py_compile mic_renamer/**/*.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_684ed01a8fc88326877500903bde8080