### PR TITLE
Improve theme validation and live reload

### DIFF
--- a/mic_renamer/config/defaults.yaml
+++ b/mic_renamer/config/defaults.yaml
@@ -13,6 +13,8 @@ theme:
   primary_blue: "#2F6FDE"
   background_white: "#FFFFFF"
   accent_red: "#D94C4C"
+  text_color: "#000000"
+  debug_minimal: false
 window:
   width: 1400
   height: 800

--- a/mic_renamer/ui/main_window.py
+++ b/mic_renamer/ui/main_window.py
@@ -18,7 +18,7 @@ from .panels.image_preview import ImagePreviewPanel
 from .panels.file_table import FileTablePanel
 from .panels.tag_panel import TagPanel
 from .panels.settings_dialog import SettingsDialog
-from .theming import theme_manager
+from . import theming
 from ..config.config_manager import config_manager
 from ..utils.state_manager import state_manager
 from ..utils.logging_setup import init_logging
@@ -37,7 +37,7 @@ class MainWindow(QWidget):
         self.setMinimumSize(800, 600)
         set_language(cfg.get("language", "en"))
         self.setWindowTitle(tr("app_title"))
-        theme_manager.apply_palette(self)
+        theming.theme_manager.apply_theme_all()
 
         layout = QVBoxLayout(self)
         self.toolbar = QToolBar()
@@ -100,8 +100,8 @@ class MainWindow(QWidget):
         dlg = SettingsDialog(self)
         if dlg.exec() == dlg.Accepted:
             config_manager.load()
-            theme_manager.reload()
-            theme_manager.apply_palette(self)
+            theming.theme_manager = theming.ThemeManager()
+            theming.theme_manager.apply_theme_all()
             self.tag_panel.rebuild()
 
 

--- a/mic_renamer/ui/panels/file_table.py
+++ b/mic_renamer/ui/panels/file_table.py
@@ -12,7 +12,7 @@ from PySide6.QtGui import QColor
 from PySide6.QtCore import Qt, QItemSelection, QItemSelectionModel, QTimer
 
 from ...logic.settings import ItemSettings
-from ..theming import theme_manager
+from .. import theming
 
 
 class FileTablePanel(QTableWidget):
@@ -40,7 +40,7 @@ class FileTablePanel(QTableWidget):
         self.itemChanged.connect(self.handle_item_changed)
         self._initial_columns = False
         QTimer.singleShot(0, self.set_equal_column_widths)
-        theme_manager.apply_palette(self)
+        theming.theme_manager.apply_theme_all()
 
     def set_equal_column_widths(self):
         if self._initial_columns:

--- a/mic_renamer/ui/panels/image_preview.py
+++ b/mic_renamer/ui/panels/image_preview.py
@@ -4,7 +4,7 @@ from PySide6.QtWidgets import QWidget, QVBoxLayout, QHBoxLayout, QPushButton, QS
 from PySide6.QtGui import QPainter, QPixmap
 from PySide6.QtCore import Qt
 
-from ..theming import theme_manager
+from .. import theming
 
 
 class ImageViewer(QGraphicsView):
@@ -166,7 +166,7 @@ class ImagePreviewPanel(QWidget):
         btn_rot_left.clicked.connect(self.viewer.rotate_left)
         btn_rot_right.clicked.connect(self.viewer.rotate_right)
         self.zoom_slider.valueChanged.connect(self.on_zoom)
-        theme_manager.apply_palette(self)
+        theming.theme_manager.apply_theme_all()
 
     def on_zoom(self, value: int):
         self.viewer._zoom_pct = value

--- a/mic_renamer/ui/panels/tag_panel.py
+++ b/mic_renamer/ui/panels/tag_panel.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from PySide6.QtWidgets import QWidget, QGridLayout, QCheckBox, QVBoxLayout, QLabel
 
 from ...logic.tag_service import tag_service
-from ..theming import theme_manager
+from .. import theming
 from ...utils.i18n import tr
 
 
@@ -18,7 +18,7 @@ class TagPanel(QWidget):
         self.tag_layout.setContentsMargins(0, 0, 0, 0)
         layout.addWidget(self.container)
         self.rebuild()
-        theme_manager.apply_palette(self)
+        theming.theme_manager.apply_theme_all()
 
     def rebuild(self) -> None:
         while self.tag_layout.count():

--- a/mic_renamer/ui/theming.py
+++ b/mic_renamer/ui/theming.py
@@ -1,28 +1,77 @@
 from __future__ import annotations
 
 from typing import Any
+import logging
 
 from PySide6.QtGui import QPalette, QColor
+from PySide6.QtWidgets import QApplication
 
 from ..config.config_manager import config_manager
+
+
+def is_valid_color(value: str) -> bool:
+    """Return True if the given string can be interpreted as a QColor."""
+    if not isinstance(value, str):
+        return False
+    col = QColor(value)
+    return col.isValid()
 
 
 class ThemeManager:
     """Apply colors defined in configuration globally."""
 
+    DEFAULTS = {
+        "primary_blue": "#2F6FDE",
+        "background_white": "#FFFFFF",
+        "accent_red": "#D94C4C",
+        "text_color": "#000000",
+        "debug_minimal": False,
+    }
+
     def __init__(self) -> None:
-        self.colors = config_manager.get_sub("theme", {})
+        self.colors: dict[str, str] = {}
+        self.debug_minimal = False
+        self.reload()
 
     def reload(self) -> None:
-        self.colors = config_manager.get_sub("theme", {})
+        cfg = config_manager.get_sub("theme", {})
+        self.debug_minimal = bool(cfg.get("debug_minimal", self.DEFAULTS["debug_minimal"]))
+        self.colors = {}
+        for key in ["primary_blue", "background_white", "accent_red", "text_color"]:
+            val = cfg.get(key, self.DEFAULTS[key])
+            if not is_valid_color(val):
+                logging.warning("Invalid color for %s: %s - using %s", key, val, self.DEFAULTS[key])
+                val = self.DEFAULTS[key]
+            self.colors[key] = val
 
-    def apply_palette(self, widget) -> None:
-        pal = widget.palette()
-        bg = QColor(self.colors.get("background_white", "#ffffff"))
-        primary = QColor(self.colors.get("primary_blue", "#2F6FDE"))
-        pal.setColor(QPalette.Window, bg)
-        pal.setColor(QPalette.Button, primary)
-        widget.setPalette(pal)
+    def apply_palette(self) -> None:
+        app = QApplication.instance()
+        if not app:
+            return
+        pal = QApplication.palette()
+        pal.setColor(QPalette.Window, QColor(self.colors["background_white"]))
+        pal.setColor(QPalette.WindowText, QColor(self.colors["text_color"]))
+        app.setPalette(pal)
+
+    def apply_widget_styles(self) -> None:
+        app = QApplication.instance()
+        if not app:
+            return
+        btn_style = (
+            f"QPushButton {{ background-color: {self.colors['primary_blue']}; color: {self.colors['text_color']}; }}"
+        )
+        header_style = (
+            f"QHeaderView::section {{ background-color: {self.colors['primary_blue']}; color: {self.colors['text_color']}; }}"
+        )
+        select_style = (
+            f"QTableView::item:selected, QTableWidget::item:selected {{ background-color: {self.colors['accent_red']}; color: {self.colors['text_color']}; }}"
+        )
+        app.setStyleSheet("\n".join([btn_style, header_style, select_style]))
+
+    def apply_theme_all(self) -> None:
+        self.apply_palette()
+        if not self.debug_minimal:
+            self.apply_widget_styles()
 
 
 # singleton


### PR DESCRIPTION
## Summary
- validate and store theme colors with fallback defaults
- set global Qt palette for background and text
- apply targeted stylesheet snippets only for specific widgets
- allow re-instantiating ThemeManager from Settings
- expose debug_minimal and theme defaults

## Testing
- `python -m py_compile mic_renamer/ui/theming.py mic_renamer/ui/panels/file_table.py mic_renamer/ui/panels/tag_panel.py mic_renamer/ui/panels/image_preview.py mic_renamer/ui/main_window.py`
- `python -m py_compile mic_renamer/config/config_manager.py mic_renamer/utils/state_manager.py`
- `pip install -q -r requirements.txt`
- `python - <<'EOF'
from mic_renamer.ui.theming import ThemeManager
from mic_renamer.config.config_manager import config_manager
cfg={'theme':{'primary_blue':'#123456','background_white':'notacolor','accent_red':'#FF0000','text_color':'#000000'}}
config_manager._data=cfg
ThemeManager()
EOF` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_684ed308620c8326b27cf7c15634a12e