### PR TITLE
Refactor theme manager for safer palette handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ Configuration files are stored in the user specific configuration directory
 environment variable to override this location. Default values are bundled in
 `mic_renamer/config/defaults.yaml` and are loaded on first start.
 
-Configuration files are stored in the user specific configuration directory
-(e.g. `~/.config/mic-renamer` on Linux). Set the `RENAMER_CONFIG_DIR`
-environment variable to override this location.
+## Theming
+
+Colors for the user interface can be customised via the `theme` section of the
+configuration file. The application validates color values before applying them
+and falls back to safe defaults if a value is invalid. Use the *Settings* dialog
+to reload the configuration and reapply the theme at runtime.

--- a/mic_renamer/config/defaults.yaml
+++ b/mic_renamer/config/defaults.yaml
@@ -14,6 +14,11 @@ theme:
   background_white: "#FFFFFF"
   accent_red: "#D94C4C"
   text_color: "#000000"
+  base_color: "#FFFFFF"
+  alternate_base_color: "#F8F9FA"
+  button_text_color: "#FFFFFF"
+  highlight_color: "#2F6FDE"
+  highlight_text_color: "#FFFFFF"
   debug_minimal: false
 window:
   width: 1400

--- a/mic_renamer/ui/main_window.py
+++ b/mic_renamer/ui/main_window.py
@@ -100,7 +100,7 @@ class MainWindow(QWidget):
         dlg = SettingsDialog(self)
         if dlg.exec() == dlg.Accepted:
             config_manager.load()
-            theming.theme_manager = theming.ThemeManager()
+            theming.theme_manager.reload()
             theming.theme_manager.apply_theme_all()
             self.tag_panel.rebuild()
 

--- a/mic_renamer/ui/panels/file_table.py
+++ b/mic_renamer/ui/panels/file_table.py
@@ -8,11 +8,9 @@ from PySide6.QtWidgets import (
     QAbstractItemView,
     QApplication,
 )
-from PySide6.QtGui import QColor
 from PySide6.QtCore import Qt, QItemSelection, QItemSelectionModel, QTimer
 
 from ...logic.settings import ItemSettings
-from .. import theming
 
 
 class FileTablePanel(QTableWidget):
@@ -40,7 +38,6 @@ class FileTablePanel(QTableWidget):
         self.itemChanged.connect(self.handle_item_changed)
         self._initial_columns = False
         QTimer.singleShot(0, self.set_equal_column_widths)
-        theming.theme_manager.apply_theme_all()
 
     def set_equal_column_widths(self):
         if self._initial_columns:
@@ -102,8 +99,6 @@ class FileTablePanel(QTableWidget):
             check_item.setCheckState(Qt.Unchecked)
             fname_item = QTableWidgetItem(os.path.basename(path))
             fname_item.setData(Qt.UserRole, path)
-            fname_item.setBackground(QColor(30, 30, 30))
-            fname_item.setForeground(QColor(220, 220, 220))
             tags_item = QTableWidgetItem("")
             suffix_item = QTableWidgetItem("")
             tags_item.setToolTip("")

--- a/mic_renamer/ui/panels/image_preview.py
+++ b/mic_renamer/ui/panels/image_preview.py
@@ -4,7 +4,6 @@ from PySide6.QtWidgets import QWidget, QVBoxLayout, QHBoxLayout, QPushButton, QS
 from PySide6.QtGui import QPainter, QPixmap
 from PySide6.QtCore import Qt
 
-from .. import theming
 
 
 class ImageViewer(QGraphicsView):
@@ -166,7 +165,6 @@ class ImagePreviewPanel(QWidget):
         btn_rot_left.clicked.connect(self.viewer.rotate_left)
         btn_rot_right.clicked.connect(self.viewer.rotate_right)
         self.zoom_slider.valueChanged.connect(self.on_zoom)
-        theming.theme_manager.apply_theme_all()
 
     def on_zoom(self, value: int):
         self.viewer._zoom_pct = value

--- a/mic_renamer/ui/panels/tag_panel.py
+++ b/mic_renamer/ui/panels/tag_panel.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from PySide6.QtWidgets import QWidget, QGridLayout, QCheckBox, QVBoxLayout, QLabel
 
 from ...logic.tag_service import tag_service
-from .. import theming
 from ...utils.i18n import tr
 
 
@@ -18,7 +17,6 @@ class TagPanel(QWidget):
         self.tag_layout.setContentsMargins(0, 0, 0, 0)
         layout.addWidget(self.container)
         self.rebuild()
-        theming.theme_manager.apply_theme_all()
 
     def rebuild(self) -> None:
         while self.tag_layout.count():

--- a/mic_renamer/ui/theming.py
+++ b/mic_renamer/ui/theming.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+"""Utility classes for loading and applying UI themes."""
+
 from typing import Any
 import logging
 
@@ -10,21 +12,25 @@ from ..config.config_manager import config_manager
 
 
 def is_valid_color(value: str) -> bool:
-    """Return True if the given string can be interpreted as a QColor."""
+    """Return ``True`` if ``value`` is a valid color string understood by ``QColor``."""
     if not isinstance(value, str):
         return False
-    col = QColor(value)
-    return col.isValid()
+    return QColor(value).isValid()
 
 
 class ThemeManager:
-    """Apply colors defined in configuration globally."""
+    """Load colors from configuration and apply them as Qt palette/stylesheet."""
 
     DEFAULTS = {
         "primary_blue": "#2F6FDE",
         "background_white": "#FFFFFF",
         "accent_red": "#D94C4C",
         "text_color": "#000000",
+        "base_color": "#FFFFFF",
+        "alternate_base_color": "#F8F9FA",
+        "button_text_color": "#FFFFFF",
+        "highlight_color": "#2F6FDE",
+        "highlight_text_color": "#FFFFFF",
         "debug_minimal": False,
     }
 
@@ -34,23 +40,34 @@ class ThemeManager:
         self.reload()
 
     def reload(self) -> None:
+        """Reload color values from the configuration with validation."""
         cfg = config_manager.get_sub("theme", {})
         self.debug_minimal = bool(cfg.get("debug_minimal", self.DEFAULTS["debug_minimal"]))
         self.colors = {}
-        for key in ["primary_blue", "background_white", "accent_red", "text_color"]:
-            val = cfg.get(key, self.DEFAULTS[key])
+        for key, default in self.DEFAULTS.items():
+            if key == "debug_minimal":
+                continue
+            val = cfg.get(key, default)
             if not is_valid_color(val):
-                logging.warning("Invalid color for %s: %s - using %s", key, val, self.DEFAULTS[key])
-                val = self.DEFAULTS[key]
+                logging.warning("Invalid color for %s: %s - using %s", key, val, default)
+                val = default
             self.colors[key] = val
 
     def apply_palette(self) -> None:
+        """Apply the base color palette to the ``QApplication`` instance."""
         app = QApplication.instance()
         if not app:
             return
-        pal = QApplication.palette()
+        pal = app.palette()
         pal.setColor(QPalette.Window, QColor(self.colors["background_white"]))
         pal.setColor(QPalette.WindowText, QColor(self.colors["text_color"]))
+        pal.setColor(QPalette.Base, QColor(self.colors["base_color"]))
+        pal.setColor(QPalette.AlternateBase, QColor(self.colors["alternate_base_color"]))
+        pal.setColor(QPalette.Text, QColor(self.colors["text_color"]))
+        pal.setColor(QPalette.Button, QColor(self.colors["primary_blue"]))
+        pal.setColor(QPalette.ButtonText, QColor(self.colors["button_text_color"]))
+        pal.setColor(QPalette.Highlight, QColor(self.colors["highlight_color"]))
+        pal.setColor(QPalette.HighlightedText, QColor(self.colors["highlight_text_color"]))
         app.setPalette(pal)
 
     def apply_widget_styles(self) -> None:
@@ -58,20 +75,48 @@ class ThemeManager:
         if not app:
             return
         btn_style = (
-            f"QPushButton {{ background-color: {self.colors['primary_blue']}; color: {self.colors['text_color']}; }}"
+            f"QPushButton {{"
+            f" background-color: {self.colors['primary_blue']};"
+            f" color: {self.colors['button_text_color']};"
+            f" border-radius: 4px;"
+            f" padding: 6px 12px;"
+            f" }}"
+        )
+        btn_pressed = (
+            f"QPushButton:pressed {{"
+            f" background-color: {self._darken(self.colors['primary_blue'], 20)};"
+            f" }}"
         )
         header_style = (
-            f"QHeaderView::section {{ background-color: {self.colors['primary_blue']}; color: {self.colors['text_color']}; }}"
+            f"QHeaderView::section {{"
+            f" background-color: {self.colors['primary_blue']};"
+            f" color: {self.colors['button_text_color']};"
+            f" padding: 4px;"
+            f" border: none;"
+            f" }}"
         )
         select_style = (
-            f"QTableView::item:selected, QTableWidget::item:selected {{ background-color: {self.colors['accent_red']}; color: {self.colors['text_color']}; }}"
+            f"QTableView::item:selected, QTreeView::item:selected {{"
+            f" background-color: {self.colors['highlight_color']};"
+            f" color: {self.colors['highlight_text_color']};"
+            f" }}"
         )
-        app.setStyleSheet("\n".join([btn_style, header_style, select_style]))
+        style_sheet = "\n".join([btn_style, btn_pressed, header_style, select_style])
+        app.setStyleSheet(style_sheet)
 
     def apply_theme_all(self) -> None:
         self.apply_palette()
         if not self.debug_minimal:
             self.apply_widget_styles()
+
+    @staticmethod
+    def _darken(hex_color: str, percent: int) -> str:
+        """Return a darker shade of ``hex_color`` by ``percent``."""
+        col = QColor(hex_color)
+        r = max(0, int(col.red() * (100 - percent) / 100))
+        g = max(0, int(col.green() * (100 - percent) / 100))
+        b = max(0, int(col.blue() * (100 - percent) / 100))
+        return QColor(r, g, b).name()
 
 
 # singleton


### PR DESCRIPTION
## Summary
- expand ThemeManager with color validation and safe defaults
- apply palette roles for base, alternate base, button colors and highlights
- trim redundant stylesheet calls in panels
- clean up FileTablePanel item styling
- document theming options in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ed53b961c8326b7c8ea9ef66268c4