### PR TITLE
Improve theme handling

### DIFF
--- a/mic_renamer/ui/main_window.py
+++ b/mic_renamer/ui/main_window.py
@@ -37,7 +37,11 @@ class MainWindow(QWidget):
         self.setMinimumSize(800, 600)
         set_language(cfg.get("language", "en"))
         self.setWindowTitle(tr("app_title"))
+        # apply the current theme before constructing child widgets so that all
+        # widgets pick up the palette and style sheet. ``setAutoFillBackground``
+        # ensures the background color from the palette is actually painted.
         theming.theme_manager.apply_theme_all()
+        self.setAutoFillBackground(True)
 
         layout = QVBoxLayout(self)
         self.toolbar = QToolBar()

--- a/mic_renamer/ui/theming.py
+++ b/mic_renamer/ui/theming.py
@@ -101,7 +101,19 @@ class ThemeManager:
             f" color: {self.colors['highlight_text_color']};"
             f" }}"
         )
-        style_sheet = "\n".join([btn_style, btn_pressed, header_style, select_style])
+        widget_style = (
+            f"QWidget {{"
+            f" background-color: {self.colors['background_white']};"
+            f" color: {self.colors['text_color']};"
+            f" }}"
+        )
+        style_sheet = "\n".join([
+            widget_style,
+            btn_style,
+            btn_pressed,
+            header_style,
+            select_style,
+        ])
         app.setStyleSheet(style_sheet)
 
     def apply_theme_all(self) -> None:


### PR DESCRIPTION
## Summary
- ensure main window palette fills background
- apply default styles to QWidget in theme manager

## Testing
- `python -m pip install --quiet -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ed89f024083268b0a4094cae34ee9