### PR TITLE
Fix SettingsDialog acceptance check

### DIFF
--- a/mic_renamer/ui/main_window.py
+++ b/mic_renamer/ui/main_window.py
@@ -10,6 +10,7 @@ from PySide6.QtWidgets import (
     QFileDialog,
     QMessageBox,
     QStyle,
+    QDialog,
 )
 from PySide6.QtGui import QAction, QIcon
 from PySide6.QtCore import Qt
@@ -102,7 +103,7 @@ class MainWindow(QWidget):
 
     def open_settings(self):
         dlg = SettingsDialog(self)
-        if dlg.exec() == dlg.Accepted:
+        if dlg.exec() == QDialog.Accepted:
             config_manager.load()
             theming.theme_manager.reload()
             theming.theme_manager.apply_theme_all()


### PR DESCRIPTION
## Summary
- import `QDialog` in `main_window.py`
- check against `QDialog.Accepted` when opening settings

## Testing
- `pip install -r requirements.txt`
- `python -m mic_renamer` *(fails: `libEGL.so.1` missing)*

------
https://chatgpt.com/codex/tasks/task_e_684ed9de7900832684c00469eb8584a9