### PR TITLE
Improve configuration management

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ A desktop application to rename photos and videos using project numbers, tags an
 Configuration files are stored in the user specific configuration directory
 (e.g. `~/.config/mic-renamer` on Linux). Set the `RENAMER_CONFIG_DIR`
 environment variable to override this location. Default values are bundled in
-`mic_renamer/config/defaults.yaml` and are loaded on first start.
+`mic_renamer/config/defaults.yaml` and are loaded on first start. The *Settings*
+dialog lets you change the path of the configuration file or reset all
+settings to these defaults.
 
 ## Theming
 

--- a/mic_renamer/utils/i18n.py
+++ b/mic_renamer/utils/i18n.py
@@ -30,7 +30,10 @@ TRANSLATIONS = {
         'hide_tags': 'Hide tags',
         'accepted_ext_label': 'Accepted File Extensions (comma separated):',
         'language_label': 'Language:',
-        'tags_label': 'Tags'
+        'tags_label': 'Tags',
+        'config_file_label': 'Config File:',
+        'browse': 'Browse...',
+        'reset_defaults': 'Reset to Defaults'
         , 'current_name': 'Current Name'
         , 'proposed_new_name': 'Proposed New Name'
         , 'renaming_files': 'Renaming files...'
@@ -65,7 +68,10 @@ TRANSLATIONS = {
         'language_label': 'Sprache:',
         'tags_label': 'Tags',
         'show_tags': 'Tags anzeigen',
-        'hide_tags': 'Tags ausblenden'
+        'hide_tags': 'Tags ausblenden',
+        'config_file_label': 'Konfigurationsdatei:',
+        'browse': 'Durchsuchen...',
+        'reset_defaults': 'Auf Standard zurücksetzen'
         , 'current_name': 'Aktueller Name'
         , 'proposed_new_name': 'Vorgeschlagener neuer Name'
         , 'renaming_files': 'Dateien werden umbenannt...'


### PR DESCRIPTION
## Summary
- allow config path changes via Settings dialog
- support resetting configuration to defaults
- document new config features

## Testing
- `python -m compileall -q mic_renamer`

------
https://chatgpt.com/codex/tasks/task_e_684f2c2ce9408326be6005571aaee7da