### PR TITLE
Fix PySide6 imports

### DIFF
--- a/mic_renamer/ui/main_window.py
+++ b/mic_renamer/ui/main_window.py
@@ -5,7 +5,7 @@ from PySide6.QtWidgets import (
     QPushButton, QSlider, QFileDialog, QMessageBox, QToolBar,
     QApplication, QLabel, QLineEdit,
     QProgressDialog, QDialog, QDialogButtonBox, QAbstractItemView,
-    QHeaderView, QStyle
+    QHeaderView, QStyle, QTableWidgetItem
 )
 from PySide6.QtGui import QColor, QAction, QIcon
 from PySide6.QtCore import Qt, QTimer, QItemSelectionModel, QItemSelection

--- a/mic_renamer/ui/panels/file_table.py
+++ b/mic_renamer/ui/panels/file_table.py
@@ -5,12 +5,11 @@ from PySide6.QtWidgets import (
     QTableWidgetItem,
     QHeaderView,
     QApplication,
-    QItemSelectionModel,
-    QItemSelection,
     QAbstractItemView,
 )
 from PySide6.QtGui import QColor
-from PySide6.QtCore import Qt, QTimer
+# Corrected import: QItemSelectionModel and QItemSelection come from QtCore, not QtWidgets
+from PySide6.QtCore import Qt, QTimer, QItemSelectionModel, QItemSelection
 
 from ...logic.settings import ItemSettings
 


### PR DESCRIPTION
## Summary
- fix imports for QItemSelectionModel and QItemSelection
- add missing QTableWidgetItem import in MainWindow

## Testing
- `python -m compileall -q mic_renamer`
- `QT_QPA_PLATFORM=offscreen timeout 5s python -m mic_renamer`

------
https://chatgpt.com/codex/tasks/task_e_684f41284a84832682a9d92eec23fc41