### PR TITLE
Fix tag loading and preview dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,6 @@ Configuration files are stored in the user specific configuration directory
 (e.g. `~/.config/mic_renamer` on Linux). Set the `RENAMER_CONFIG_DIR`
 environment variable to override this location. Defaults are bundled in
 `mic_renamer/config/defaults.yaml` and will be merged with your custom
-configuration at startup.
+configuration at startup. A default `tags.json` file containing available tag
+codes is copied to the configuration directory on first run if it does not
+already exist.

--- a/mic_renamer/config/config_manager.py
+++ b/mic_renamer/config/config_manager.py
@@ -27,6 +27,8 @@ class ConfigManager:
             except Exception:
                 data = {}
         defaults = yaml.safe_load(self.defaults_path.read_text())
+        # ensure default path for the tags file in user config directory
+        defaults.setdefault("tags_file", str(Path(get_config_dir()) / "tags.json"))
         self._config = {**defaults, **data}
         return self._config
 

--- a/mic_renamer/config/defaults.yaml
+++ b/mic_renamer/config/defaults.yaml
@@ -9,3 +9,4 @@ accepted_extensions:
   - .mov
   - .mkv
 language: en
+tags_file: tags.json

--- a/mic_renamer/logic/tag_loader.py
+++ b/mic_renamer/logic/tag_loader.py
@@ -6,6 +6,7 @@ from .. import config_manager
 from ..utils.path_utils import get_config_dir
 
 DEFAULT_TAGS_FILE = Path(get_config_dir()) / "tags.json"
+BUNDLED_TAGS_FILE = Path(__file__).resolve().parent.parent / "config" / "tags.json"
 
 CONFIG_TAGS_FILE = config_manager.get("tags_file")
 
@@ -14,10 +15,21 @@ ENV_TAGS_FILE = "RENAMER_TAGS_FILE"
 def load_tags(file_path: str | None = None) -> dict:
     """Load tag definitions from a JSON file."""
     if file_path is None:
-        file_path = os.environ.get(ENV_TAGS_FILE) or str(CONFIG_TAGS_FILE or DEFAULT_TAGS_FILE)
+        file_path = os.environ.get(ENV_TAGS_FILE) or CONFIG_TAGS_FILE or DEFAULT_TAGS_FILE
     path = Path(file_path)
+    if not path.is_absolute():
+        path = Path(get_config_dir()) / path
     if not path.is_file():
-        return {}
+        if path == DEFAULT_TAGS_FILE:
+            try:
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(BUNDLED_TAGS_FILE.read_text(), encoding="utf-8")
+            except Exception:
+                pass
+    if not path.is_file():
+        path = BUNDLED_TAGS_FILE
+        if not path.is_file():
+            return {}
     with path.open("r", encoding="utf-8") as f:
         return json.load(f)
 

--- a/mic_renamer/ui/main_window.py
+++ b/mic_renamer/ui/main_window.py
@@ -5,7 +5,7 @@ from PySide6.QtWidgets import (
     QPushButton, QSlider, QFileDialog, QMessageBox, QToolBar,
     QApplication, QLabel, QLineEdit,
     QProgressDialog, QDialog, QDialogButtonBox, QAbstractItemView,
-    QHeaderView, QStyle, QTableWidgetItem
+    QHeaderView, QStyle, QTableWidget, QTableWidgetItem
 )
 from PySide6.QtGui import QColor, QAction, QIcon
 from PySide6.QtCore import Qt, QTimer, QItemSelectionModel, QItemSelection


### PR DESCRIPTION
## Summary
- copy default tags.json to user config directory if missing
- add `tags_file` default in configuration
- load tags.json relative to config dir when necessary
- fix missing QTableWidget import
- document default tags file behavior

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_684f44296f708326b66de61db41ac75a