### PR TITLE
Implement settings enhancements and tag indicators

### DIFF
--- a/mic_renamer/config/config_manager.py
+++ b/mic_renamer/config/config_manager.py
@@ -51,3 +51,11 @@ class ConfigManager:
         cfg = self.load()
         cfg[key] = value
         self.save(cfg)
+
+    def restore_defaults(self) -> dict:
+        """Overwrite config file with bundled defaults."""
+        defaults = yaml.safe_load(self.defaults_path.read_text())
+        defaults.setdefault("tags_file", str(Path(get_config_dir()) / "tags.json"))
+        self._config = defaults
+        self.save(defaults)
+        return defaults

--- a/mic_renamer/logic/tag_loader.py
+++ b/mic_renamer/logic/tag_loader.py
@@ -30,7 +30,16 @@ def load_tags(file_path: str | None = None) -> dict:
         path = BUNDLED_TAGS_FILE
         if not path.is_file():
             return {}
-    with path.open("r", encoding="utf-8") as f:
-        return json.load(f)
+        with path.open("r", encoding="utf-8") as f:
+            return json.load(f)
+
+
+def restore_default_tags() -> None:
+    """Reset the user's tags.json to the bundled defaults."""
+    try:
+        DEFAULT_TAGS_FILE.parent.mkdir(parents=True, exist_ok=True)
+        DEFAULT_TAGS_FILE.write_text(BUNDLED_TAGS_FILE.read_text(), encoding="utf-8")
+    except Exception:
+        pass
 
 

--- a/mic_renamer/utils/i18n.py
+++ b/mic_renamer/utils/i18n.py
@@ -30,7 +30,8 @@ TRANSLATIONS = {
         'hide_tags': 'Hide tags',
         'accepted_ext_label': 'Accepted File Extensions (comma separated):',
         'language_label': 'Language:',
-        'tags_label': 'Tags'
+        'tags_label': 'Tags',
+        'restore_defaults': 'Restore Defaults'
         , 'current_name': 'Current Name'
         , 'proposed_new_name': 'Proposed New Name'
         , 'renaming_files': 'Renaming files...'
@@ -64,6 +65,7 @@ TRANSLATIONS = {
         'accepted_ext_label': 'Erlaubte Dateiendungen (durch Komma getrennt):',
         'language_label': 'Sprache:',
         'tags_label': 'Tags',
+        'restore_defaults': 'Standardeinstellungen wiederherstellen',
         'show_tags': 'Tags anzeigen',
         'hide_tags': 'Tags ausblenden'
         , 'current_name': 'Aktueller Name'


### PR DESCRIPTION
## Summary
- add restore_defaults key to translations
- allow resetting configuration via `ConfigManager.restore_defaults`
- make gear icon fallback a drawn Unicode gear
- show partial tag selection with `[~]` label in tag panel
- refresh selection after tag toggles
- add buttons to remove tags and restore defaults in settings dialog
- provide utility to restore default tag file

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684f482ccbe08326babf74a9f6a75570