### PR TITLE
Fix TagPanel crash when loading tags

### DIFF
--- a/mic_renamer/logic/tag_loader.py
+++ b/mic_renamer/logic/tag_loader.py
@@ -28,10 +28,16 @@ def load_tags(file_path: str | None = None) -> dict:
                 pass
     if not path.is_file():
         path = BUNDLED_TAGS_FILE
-        if not path.is_file():
-            return {}
+    if not path.is_file():
+        return {}
+    try:
         with path.open("r", encoding="utf-8") as f:
-            return json.load(f)
+            data = json.load(f)
+        if isinstance(data, dict):
+            return data
+    except Exception:
+        pass
+    return {}
 
 
 def restore_default_tags() -> None:

--- a/mic_renamer/utils/i18n.py
+++ b/mic_renamer/utils/i18n.py
@@ -36,6 +36,7 @@ TRANSLATIONS = {
         , 'proposed_new_name': 'Proposed New Name'
         , 'renaming_files': 'Renaming files...'
         , 'abort': 'Abort'
+        , 'no_tags_configured': 'No tags configured'
     },
     'de': {
         'app_title': 'Foto/Video Umbenenner',
@@ -72,6 +73,7 @@ TRANSLATIONS = {
         , 'proposed_new_name': 'Vorgeschlagener neuer Name'
         , 'renaming_files': 'Dateien werden umbenannt...'
         , 'abort': 'Abbrechen'
+        , 'no_tags_configured': 'Keine Tags konfiguriert'
     }
 }
 

--- a/tests/test_tag_panel.py
+++ b/tests/test_tag_panel.py
@@ -1,0 +1,47 @@
+import os
+import pytest
+from PySide6.QtWidgets import QApplication, QLabel, QCheckBox
+
+from mic_renamer.ui.panels.tag_panel import TagPanel
+
+
+@pytest.fixture(scope="module")
+def app():
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+def test_rebuild_with_none(monkeypatch, app):
+    monkeypatch.setattr("mic_renamer.ui.panels.tag_panel.load_tags", lambda: None)
+    panel = TagPanel()
+    assert panel.tags_info == {}
+    assert panel.tag_layout.count() == 1
+    widget = panel.tag_layout.itemAt(0).widget()
+    assert isinstance(widget, QLabel)
+
+
+def test_rebuild_with_empty(monkeypatch, app):
+    monkeypatch.setattr("mic_renamer.ui.panels.tag_panel.load_tags", lambda: {})
+    panel = TagPanel()
+    assert panel.tags_info == {}
+    assert panel.tag_layout.count() == 1
+    widget = panel.tag_layout.itemAt(0).widget()
+    assert isinstance(widget, QLabel)
+
+
+def test_rebuild_with_tags(monkeypatch, app):
+    monkeypatch.setattr(
+        "mic_renamer.ui.panels.tag_panel.load_tags",
+        lambda: {"A": "Alpha", "B": "Beta"},
+    )
+    panel = TagPanel()
+    assert set(panel.tags_info.keys()) == {"A", "B"}
+    checkboxes = [
+        panel.tag_layout.itemAt(i).widget()
+        for i in range(panel.tag_layout.count())
+        if isinstance(panel.tag_layout.itemAt(i).widget(), QCheckBox)
+    ]
+    assert len(checkboxes) == 2


### PR DESCRIPTION
## Summary
- handle tag file loading robustly
- validate loaded tag data in TagPanel
- show a message when no tags are configured
- provide translations for this message
- add unit tests for TagPanel

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f4aac4cf083268d4386edbe35b7b8