### PR TITLE
Fix tag panel toggling

### DIFF
--- a/mic_renamer/ui/main_window.py
+++ b/mic_renamer/ui/main_window.py
@@ -299,7 +299,9 @@ class RenamerApp(QWidget):
                 settings.tags.discard(code)
             tags_str = ",".join(sorted(settings.tags))
             cell_tags = self.table_widget.item(row, 2)
+            self._ignore_table_changes = True
             cell_tags.setText(tags_str)
+            self._ignore_table_changes = False
             cell_tags.setToolTip(tags_str)
             self.update_row_background(row, settings)
         self.table_widget.sync_check_column()


### PR DESCRIPTION
## Summary
- update tag toggling logic to ignore table change signal

## Testing
- `pytest -q` *(fails: ImportError: libEGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_684f4d7f728c83268144553a6ba8a90d