### PR TITLE
Improve MC number entry with pincode widget

### DIFF
--- a/mic_renamer/ui/main_window.py
+++ b/mic_renamer/ui/main_window.py
@@ -3,7 +3,7 @@ import re
 from PySide6.QtWidgets import (
     QWidget, QSplitter, QHBoxLayout, QVBoxLayout, QGridLayout,
     QPushButton, QSlider, QFileDialog, QMessageBox, QToolBar,
-    QApplication, QLabel, QLineEdit,
+    QApplication, QLabel,
     QProgressDialog, QDialog, QDialogButtonBox, QAbstractItemView,
     QHeaderView, QStyle, QTableWidget, QTableWidgetItem
 )
@@ -14,6 +14,7 @@ from .. import config_manager
 from ..utils.i18n import tr, set_language
 from .settings_dialog import SettingsDialog
 from .panels import ImageViewer, AspectRatioWidget, DragDropTableWidget, TagPanel
+from .project_number_input import ProjectNumberInput
 from ..logic.settings import ItemSettings
 from ..logic.renamer import Renamer
 
@@ -152,11 +153,7 @@ class RenamerApp(QWidget):
 
         tb.addSeparator()
         self.lbl_project = QLabel(tr("project_number_label"))
-        self.input_project = QLineEdit()
-        self.input_project.setInputMask("C000000;_")
-        self.input_project.setText("C")
-        self.input_project.setMaximumWidth(120)
-        self.input_project.setPlaceholderText(tr("project_number_placeholder"))
+        self.input_project = ProjectNumberInput()
         tb.addWidget(self.lbl_project)
         tb.addWidget(self.input_project)
 
@@ -181,7 +178,6 @@ class RenamerApp(QWidget):
             action.setToolTip(tr(key))
         # update form labels
         self.lbl_project.setText(tr("project_number_label"))
-        self.input_project.setPlaceholderText(tr("project_number_placeholder"))
         if self.tag_panel.isVisible():
             self.btn_toggle_tags.setText(tr("hide_tags"))
         else:

--- a/mic_renamer/ui/project_number_input.py
+++ b/mic_renamer/ui/project_number_input.py
@@ -1,0 +1,77 @@
+"""Input widget for project numbers like C123456 using individual digit boxes."""
+
+from __future__ import annotations
+
+from PySide6.QtWidgets import QWidget, QHBoxLayout, QLabel, QLineEdit
+from PySide6.QtCore import Qt, Signal
+import re
+
+
+class ProjectNumberInput(QWidget):
+    """Widget for entering project numbers as ``C`` followed by six digits."""
+
+    textChanged = Signal(str)
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(2)
+        self._digits: list[QLineEdit] = []
+        self.prefix = QLabel("C")
+        layout.addWidget(self.prefix)
+        self.setMaximumWidth(160)
+        for i in range(6):
+            edit = QLineEdit()
+            edit.setMaxLength(1)
+            edit.setFixedWidth(20)
+            edit.setAlignment(Qt.AlignCenter)
+            edit.setObjectName(f"digit_{i}")
+            edit.textChanged.connect(lambda _=None, idx=i: self._on_digit_changed(idx))
+            self._digits.append(edit)
+            layout.addWidget(edit)
+        self.setFocusProxy(self._digits[0])
+
+    # public API ----------------------------------------------------------
+    def text(self) -> str:
+        digits = ''.join(d.text() for d in self._digits)
+        return f"C{digits}"
+
+    def setText(self, text: str) -> None:  # noqa: N802
+        digits = re.sub(r"\D", "", text)[:6]
+        for i, d in enumerate(self._digits):
+            d.blockSignals(True)
+            d.setText(digits[i] if i < len(digits) else "")
+            d.blockSignals(False)
+        if digits:
+            self._focus_next(len(digits) - 1)
+        else:
+            self._digits[0].setFocus()
+        self.textChanged.emit(self.text())
+
+    def clear(self) -> None:
+        self.setText("")
+
+    # internals -----------------------------------------------------------
+    def _on_digit_changed(self, idx: int) -> None:
+        text = self._digits[idx].text()
+        if text:
+            self._focus_next(idx)
+        self.textChanged.emit(self.text())
+
+    def _focus_next(self, idx: int) -> None:
+        if idx < len(self._digits) - 1:
+            self._digits[idx + 1].setFocus()
+
+    def keyPressEvent(self, event) -> None:  # noqa: D401
+        """Handle backspace navigation between digit boxes."""
+        if event.key() == Qt.Key_Backspace:
+            for idx, edit in enumerate(self._digits):
+                if edit.hasFocus():
+                    if edit.text():
+                        break
+                    if idx > 0:
+                        self._digits[idx - 1].setFocus()
+                        self._digits[idx - 1].setText("")
+                    break
+        super().keyPressEvent(event)


### PR DESCRIPTION
## Summary
- create `ProjectNumberInput` widget for C-prefixed pincode entry
- integrate the new widget into the main toolbar

## Testing
- `pytest -q` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_684fb87618388326ae8605e63a97509a