### PR TITLE
Save project number and settings dialog size

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,5 @@ environment variable to override this location. Defaults are bundled in
 `mic_renamer/config/defaults.yaml` and will be merged with your custom
 configuration at startup. A default `tags.json` file containing available tag
 codes is copied to the configuration directory on first run if it does not
-already exist.
+already exist. The application also remembers the last used project number so it
+is restored on the next launch.

--- a/mic_renamer/config/defaults.yaml
+++ b/mic_renamer/config/defaults.yaml
@@ -10,3 +10,4 @@ accepted_extensions:
   - .mkv
 language: en
 tags_file: tags.json
+last_project_number: ""

--- a/mic_renamer/ui/main_window.py
+++ b/mic_renamer/ui/main_window.py
@@ -154,17 +154,22 @@ class RenamerApp(QWidget):
         tb.addSeparator()
         self.lbl_project = QLabel(tr("project_number_label"))
         self.input_project = ProjectNumberInput()
+        self.input_project.setText(config_manager.get("last_project_number", ""))
+        self.input_project.textChanged.connect(self.save_last_project_number)
         tb.addWidget(self.lbl_project)
         tb.addWidget(self.input_project)
 
 
     def open_settings(self):
-        dlg = SettingsDialog(self)
+        dlg = SettingsDialog(self, state_manager=self.state_manager)
         if dlg.exec() == QDialog.Accepted:
             cfg = config_manager.load()
             set_language(cfg.get("language", "en"))
             self.update_translations()
             self.rebuild_tag_checkboxes()
+
+    def save_last_project_number(self, text: str) -> None:
+        config_manager.set("last_project_number", text.strip())
 
     def update_translations(self):
         self.setWindowTitle(tr("app_title"))

--- a/mic_renamer/ui/settings_dialog.py
+++ b/mic_renamer/ui/settings_dialog.py
@@ -5,17 +5,28 @@ from PySide6.QtWidgets import (
 )
 from PySide6.QtCore import Qt
 
+from ..utils.state_manager import StateManager
+
 from .. import config_manager
 from ..logic.tag_loader import load_tags
 from ..utils.i18n import tr
 
 
 class SettingsDialog(QDialog):
-    def __init__(self, parent=None):
+    def __init__(self, parent=None, state_manager: StateManager | None = None):
         super().__init__(parent)
+        self.state_manager = state_manager
         self.setWindowTitle(tr("settings_title"))
         self.cfg = config_manager.load().copy()
         layout = QVBoxLayout(self)
+
+        # restore size or use larger defaults
+        if self.state_manager:
+            width = self.state_manager.get("settings_width", 700)
+            height = self.state_manager.get("settings_height", 500)
+        else:
+            width, height = 700, 500
+        self.resize(width, height)
 
         # accepted extensions
         layout.addWidget(QLabel(tr("accepted_ext_label")))
@@ -116,4 +127,11 @@ class SettingsDialog(QDialog):
             self.tbl_tags.insertRow(row)
             self.tbl_tags.setItem(row, 0, QTableWidgetItem(code))
             self.tbl_tags.setItem(row, 1, QTableWidgetItem(desc))
+
+    def closeEvent(self, event):
+        if self.state_manager:
+            self.state_manager.set("settings_width", self.width())
+            self.state_manager.set("settings_height", self.height())
+            self.state_manager.save()
+        super().closeEvent(event)
 


### PR DESCRIPTION
## Summary
- persist last project number across sessions
- make settings dialog larger and remember its size
- document saved project number

## Testing
- `pytest -q` *(fails: ImportError: libEGL.so.1 cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_684fc27407f08326a06d6f04836a310d