### PR TITLE
Enhance tag detection on import

### DIFF
--- a/mic_renamer/logic/tag_service.py
+++ b/mic_renamer/logic/tag_service.py
@@ -1,0 +1,28 @@
+"""Utility functions around tag operations."""
+from __future__ import annotations
+
+import os
+import re
+from typing import Iterable, Set
+
+
+def extract_tags_from_name(name: str, valid_tags: Iterable[str]) -> set[str]:
+    """Extract known tag codes from a file name.
+
+    Parameters
+    ----------
+    name: str
+        File name or path to analyze.
+    valid_tags: Iterable[str]
+        Collection of valid tag codes.
+
+    Returns
+    -------
+    set[str]
+        Tags found in ``name`` that are present in ``valid_tags``.
+    """
+    base = os.path.basename(name)
+    base, _ = os.path.splitext(base)
+    tokens = re.split(r"[^A-Za-z0-9]+", base)
+    codes = set(valid_tags)
+    return {t for t in tokens if t in codes}

--- a/tests/test_tag_apply.py
+++ b/tests/test_tag_apply.py
@@ -25,3 +25,27 @@ def test_checkbox_applies_tag(app):
     item0 = win.table_widget.item(0, 1)
     settings = item0.data(ROLE_SETTINGS)
     assert code in settings.tags
+
+
+def test_existing_tags_detected(app, monkeypatch):
+    tags = {"A": "Alpha", "B": "Beta"}
+    monkeypatch.setattr(
+        "mic_renamer.logic.tag_loader.load_tags",
+        lambda: tags,
+    )
+    monkeypatch.setattr(
+        "mic_renamer.ui.panels.file_table.load_tags",
+        lambda: tags,
+    )
+    win = RenamerApp()
+    win.table_widget.add_paths(["/tmp/image_A_B.jpg"])
+    win.table_widget.selectRow(0)
+    cell_text = win.table_widget.item(0, 2).text()
+    assert cell_text == "A,B"
+    item0 = win.table_widget.item(0, 1)
+    settings = item0.data(ROLE_SETTINGS)
+    assert settings.tags == {"A", "B"}
+    win.on_table_selection_changed()
+    assert win.tag_panel.checkbox_map["A"].checkState() == Qt.Checked
+    assert win.tag_panel.checkbox_map["B"].checkState() == Qt.Checked
+


### PR DESCRIPTION
## Summary
- add `tag_service` module with helper to parse tags from filenames
- parse tags when adding paths in `DragDropTableWidget`
- test tag detection logic

## Testing
- `pytest -vv` *(fails: `tests/test_tag_apply.py::test_existing_tags_detected` hangs due to PySide6 issues)*

------
https://chatgpt.com/codex/tasks/task_e_684fe5b712388326b223e8ffa3b4a71d