### PR TITLE
Fix None item error during row background update

### DIFF
--- a/mic_renamer/ui/main_window.py
+++ b/mic_renamer/ui/main_window.py
@@ -334,6 +334,8 @@ class RenamerApp(QWidget):
     def update_row_background(self, row: int, settings: ItemSettings):
         for col in range(5):
             item = self.table_widget.item(row, col)
+            if not item:
+                continue
             if settings and (settings.suffix or settings.tags):
                 item.setBackground(QColor('#335533'))
                 item.setForeground(QColor('#ffffff'))


### PR DESCRIPTION
## Summary
- safeguard `update_row_background` against missing table items so row background updates do not crash when items are added dynamically

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PySide6')*

------
https://chatgpt.com/codex/tasks/task_e_685026f746988326a18e2383e8c4e1cc