### PR TITLE
Add public helper for tag usage path

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,11 @@ configuration at startup. A default `tags.json` file containing available tag
 codes is copied to the configuration directory on first run if it does not
 already exist. The application also remembers the last used project number so it
 is restored on the next launch.
+
+Tag usage statistics are written to ``tag_usage.json`` in the same
+configuration directory. You can discover the full path programmatically:
+
+```python
+from mic_renamer.logic.tag_usage import get_usage_path
+print(get_usage_path())
+```

--- a/mic_renamer/logic/tag_usage.py
+++ b/mic_renamer/logic/tag_usage.py
@@ -10,10 +10,16 @@ from ..utils.path_utils import get_config_dir
 
 
 def _get_usage_path() -> Path:
+    """Internal helper returning the resolved usage file path."""
     path = Path(config_manager.get("tag_usage_file", "tag_usage.json"))
     if not path.is_absolute():
         path = Path(get_config_dir()) / path
     return path
+
+
+def get_usage_path() -> Path:
+    """Return the absolute path to ``tag_usage.json``."""
+    return _get_usage_path()
 
 
 def load_counts() -> dict[str, int]:


### PR DESCRIPTION
## Summary
- add a public `get_usage_path()` helper
- document the location of `tag_usage.json`

## Testing
- `pytest -q` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_685081faae7c8326985ba10dee96f9fc