### PR TITLE
Fix tag usage tracking and layout

### DIFF
--- a/mic_renamer/logic/renamer.py
+++ b/mic_renamer/logic/renamer.py
@@ -6,6 +6,7 @@ from PySide6.QtWidgets import QMessageBox
 
 from .settings import ItemSettings, RenameConfig
 from ..utils.file_utils import ensure_unique_name
+from .tag_usage import increment_tags
 
 class Renamer:
     def __init__(self, project: str, items: list[ItemSettings], config: RenameConfig | None = None, dest_dir: str | None = None):
@@ -44,6 +45,7 @@ class Renamer:
         return mapping
 
     def execute_rename(self, mapping: list[tuple[ItemSettings, str, str]], parent_widget):
+        used_tags = []
         for item, orig, new in mapping:
             try:
                 orig_abs = os.path.abspath(orig)
@@ -51,9 +53,12 @@ class Renamer:
                 if orig_abs != new_abs:
                     os.rename(orig, new)
                     item.original_path = new
+                    used_tags.extend(item.tags)
             except Exception as e:
                 QMessageBox.warning(
                     parent_widget,
                     "Rename Failed",
                     f"Fehler beim Umbenennen:\n{orig}\n→ {new}\nError: {e}"
                 )
+        if used_tags:
+            increment_tags(used_tags)

--- a/mic_renamer/ui/panels/tag_panel.py
+++ b/mic_renamer/ui/panels/tag_panel.py
@@ -47,14 +47,12 @@ class TagPanel(QWidget):
             self.tags_info.items(), key=lambda kv: usage.get(kv[0], 0), reverse=True
         )
         columns = 4
-        row = col = 0
-        for code, desc in sorted_tags:
+        rows = (len(sorted_tags) + columns - 1) // columns
+        for idx, (code, desc) in enumerate(sorted_tags):
+            row = idx % rows
+            col = idx // rows
             cb = QCheckBox(f"{code}: {desc}")
             cb.setProperty("code", code)
             cb.stateChanged.connect(lambda state, c=code: self.tagToggled.emit(c, state))
             self.tag_layout.addWidget(cb, row, col)
             self.checkbox_map[code] = cb
-            col += 1
-            if col >= columns:
-                col = 0
-                row += 1


### PR DESCRIPTION
## Summary
- update tag panel layout calculation for column-wise ordering
- increment tag usage counts in `Renamer.execute_rename`

## Testing
- `pytest -q` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_68508c89a0c48326a3e2085ebb092999