### PR TITLE
Improve checkbox keyboard navigation

### DIFF
--- a/mic_renamer/ui/components.py
+++ b/mic_renamer/ui/components.py
@@ -1,6 +1,6 @@
 # ui/components.py
 
-from PySide6.QtWidgets import QListWidget, QListWidgetItem
+from PySide6.QtWidgets import QListWidget, QListWidgetItem, QCheckBox
 from PySide6.QtCore import Qt
 import os
 
@@ -46,3 +46,14 @@ class DragDropListWidget(QListWidget):
             event.acceptProposedAction()
         else:
             super().dropEvent(event)
+
+
+class EnterToggleCheckBox(QCheckBox):
+    """QCheckBox that toggles when Return or Enter is pressed."""
+
+    def keyPressEvent(self, event) -> None:  # noqa: D401
+        if event.key() in (Qt.Key_Return, Qt.Key_Enter):
+            self.toggle()
+            event.accept()
+        else:
+            super().keyPressEvent(event)

--- a/mic_renamer/ui/panels/compression_settings.py
+++ b/mic_renamer/ui/panels/compression_settings.py
@@ -8,9 +8,9 @@ from PySide6.QtWidgets import (
     QFormLayout,
     QDoubleSpinBox,
     QSpinBox,
-    QCheckBox,
     QPushButton,
 )
+from ..components import EnterToggleCheckBox
 
 from ... import config_manager
 from ...utils.i18n import tr
@@ -35,11 +35,11 @@ class CompressionSettingsPanel(QWidget):
         self.spin_quality.setValue(int(cfg.get("compression_quality", 95)))
         layout.addRow(tr("quality_label"), self.spin_quality)
 
-        self.chk_reduce = QCheckBox(tr("reduce_resolution_label"))
+        self.chk_reduce = EnterToggleCheckBox(tr("reduce_resolution_label"))
         self.chk_reduce.setChecked(cfg.get("compression_reduce_resolution", True))
         layout.addRow(self.chk_reduce)
 
-        self.chk_resize_only = QCheckBox(tr("resize_only_label"))
+        self.chk_resize_only = EnterToggleCheckBox(tr("resize_only_label"))
         self.chk_resize_only.setChecked(cfg.get("compression_resize_only", False))
         layout.addRow(self.chk_resize_only)
 

--- a/mic_renamer/ui/panels/tag_panel.py
+++ b/mic_renamer/ui/panels/tag_panel.py
@@ -1,5 +1,6 @@
 """Panel showing available tags as checkboxes."""
-from PySide6.QtWidgets import QWidget, QGridLayout, QVBoxLayout, QLabel, QCheckBox
+from PySide6.QtWidgets import QWidget, QGridLayout, QVBoxLayout, QLabel
+from ..components import EnterToggleCheckBox
 from PySide6.QtCore import Qt, Signal
 import logging
 
@@ -22,7 +23,7 @@ class TagPanel(QWidget):
         self.tag_layout = QGridLayout(self.checkbox_container)
         self.tag_layout.setContentsMargins(0, 0, 0, 0)
         layout.addWidget(self.checkbox_container)
-        self.checkbox_map: dict[str, QCheckBox] = {}
+        self.checkbox_map: dict[str, EnterToggleCheckBox] = {}
         self.tags_info: dict[str, str] | None = tags_info
         self.rebuild()
 
@@ -51,7 +52,7 @@ class TagPanel(QWidget):
         for idx, (code, desc) in enumerate(sorted_tags):
             row = idx % rows
             col = idx // rows
-            cb = QCheckBox(f"{code}: {desc}")
+            cb = EnterToggleCheckBox(f"{code}: {desc}")
             cb.setProperty("code", code)
             cb.stateChanged.connect(lambda state, c=code: self.tagToggled.emit(c, state))
             self.tag_layout.addWidget(cb, row, col)

--- a/tests/test_tag_panel.py
+++ b/tests/test_tag_panel.py
@@ -1,6 +1,8 @@
 import os
 import pytest
 from PySide6.QtWidgets import QApplication, QLabel, QCheckBox
+from PySide6.QtCore import Qt
+from PySide6.QtTest import QTest
 
 from mic_renamer.ui.panels.tag_panel import TagPanel
 
@@ -45,3 +47,17 @@ def test_rebuild_with_tags(monkeypatch, app):
         if isinstance(panel.tag_layout.itemAt(i).widget(), QCheckBox)
     ]
     assert len(checkboxes) == 2
+
+
+def test_enter_toggles_checkbox(monkeypatch, app):
+    monkeypatch.setattr(
+        "mic_renamer.ui.panels.tag_panel.load_tags",
+        lambda: {"E": "Echo"},
+    )
+    panel = TagPanel()
+    cb = next(iter(panel.checkbox_map.values()))
+    assert cb.checkState() == Qt.Unchecked
+    QTest.keyClick(cb, Qt.Key_Return)
+    assert cb.checkState() == Qt.Checked
+    QTest.keyClick(cb, Qt.Key_Return)
+    assert cb.checkState() == Qt.Unchecked


### PR DESCRIPTION
## Summary
- add EnterToggleCheckBox widget so Return key toggles checkboxes
- use EnterToggleCheckBox in tag panel and compression settings panel
- add regression test for Enter key behaviour

## Testing
- `PYTHONPATH=. pytest tests/test_tag_panel.py -q`
- `PYTHONPATH=. pytest tests/test_tag_apply.py -q` *(fails: hangs due to Qt)*

------
https://chatgpt.com/codex/tasks/task_e_6851954f380483269ece59b73494ff17