### PR TITLE
Fix executable entry point

### DIFF
--- a/mic_renamer/__main__.py
+++ b/mic_renamer/__main__.py
@@ -1,4 +1,8 @@
-from .app import Application
+"""Application entry point for running as a script or packaged executable."""
+
+# Use an absolute import so the module works when executed directly
+# (e.g. when bundled with PyInstaller).
+from mic_renamer.app import Application
 
 
 def main() -> int:


### PR DESCRIPTION
## Summary
- avoid relative import in `__main__.py` so PyInstaller builds run correctly

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: `ImportError: libEGL.so.1: cannot open shared object file`)*

------
https://chatgpt.com/codex/tasks/task_e_68526c5749308326b8ae988bf9fcf9ff