### PR TITLE
Fix missing defaults in packaged app

### DIFF
--- a/mic_renamer/__main__.py
+++ b/mic_renamer/__main__.py
@@ -1,4 +1,8 @@
-from .app import Application
+"""Application entry point for running as a script or packaged executable."""
+
+# Use an absolute import so the module works when executed directly
+# (e.g. when bundled with PyInstaller).
+from mic_renamer.app import Application
 
 
 def main() -> int:

--- a/mic_renamer/config/config_manager.py
+++ b/mic_renamer/config/config_manager.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from importlib import resources
 import yaml
 
 from ..utils.path_utils import get_config_dir
@@ -14,7 +15,8 @@ class ConfigManager:
         self.config_dir = get_config_dir()
         self.config_file = Path(self.config_dir) / "app_settings.yaml"
         self._config: dict | None = None
-        self.defaults_path = Path(__file__).with_name("defaults.yaml")
+        # load defaults via importlib.resources so PyInstaller bundles work
+        self.defaults_path = resources.files(__package__) / "defaults.yaml"
 
     def load(self) -> dict:
         """Load configuration from disk merging with defaults."""


### PR DESCRIPTION
## Summary
- ensure `defaults.yaml` is located via `importlib.resources` when running from a PyInstaller build

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: `ImportError: libEGL.so.1: cannot open shared object file`)*

------
https://chatgpt.com/codex/tasks/task_e_68526c5749308326b8ae988bf9fcf9ff