### PR TITLE
Fix missing defaults in packaged app

### DIFF
--- a/mic_renamer/__main__.py
+++ b/mic_renamer/__main__.py
@@ -1,4 +1,8 @@
-from .app import Application
+"""Application entry point for running as a script or packaged executable."""
+
+# Use an absolute import so the module works when executed directly
+# (e.g. when bundled with PyInstaller).
+from mic_renamer.app import Application
 
 
 def main() -> int:

--- a/mic_renamer/app.py
+++ b/mic_renamer/app.py
@@ -3,7 +3,7 @@ from PySide6.QtWidgets import QApplication
 from PySide6.QtGui import QIcon
 from PySide6.QtCore import Qt
 import sys
-from pathlib import Path
+from importlib import resources
 
 from .ui.main_window import RenamerApp
 from .utils.state_manager import StateManager
@@ -20,7 +20,7 @@ class Application:
         except Exception:
             pass
         self.app = QApplication(sys.argv)
-        logo = Path(__file__).resolve().parents[1] / "favicon.png"
+        logo = resources.files("mic_renamer") / "favicon.png"
         if logo.is_file():
             self.app.setWindowIcon(QIcon(str(logo)))
         # create config files on first run

--- a/mic_renamer/config/config_manager.py
+++ b/mic_renamer/config/config_manager.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from importlib import resources
 import yaml
 
 from ..utils.path_utils import get_config_dir
@@ -14,7 +15,8 @@ class ConfigManager:
         self.config_dir = get_config_dir()
         self.config_file = Path(self.config_dir) / "app_settings.yaml"
         self._config: dict | None = None
-        self.defaults_path = Path(__file__).with_name("defaults.yaml")
+        # load defaults via importlib.resources so PyInstaller bundles work
+        self.defaults_path = resources.files(__package__) / "defaults.yaml"
 
     def load(self) -> dict:
         """Load configuration from disk merging with defaults."""

--- a/mic_renamer/logic/tag_loader.py
+++ b/mic_renamer/logic/tag_loader.py
@@ -1,12 +1,13 @@
 import json
 import os
 from pathlib import Path
+from importlib import resources
 
 from .. import config_manager
 from ..utils.path_utils import get_config_dir
 
 DEFAULT_TAGS_FILE = Path(get_config_dir()) / "tags.json"
-BUNDLED_TAGS_FILE = Path(__file__).resolve().parent.parent / "config" / "tags.json"
+BUNDLED_TAGS_FILE = resources.files("mic_renamer.config") / "tags.json"
 
 CONFIG_TAGS_FILE = config_manager.get("tags_file")
 

--- a/mic_renamer/ui/panels/file_table.py
+++ b/mic_renamer/ui/panels/file_table.py
@@ -10,7 +10,8 @@ from PySide6.QtWidgets import (
 from PySide6.QtGui import QColor
 # Corrected import: QItemSelectionModel and QItemSelection come from QtCore, not QtWidgets
 from PySide6.QtCore import Qt, QTimer, QItemSelectionModel, QItemSelection
-from pathlib import Path, PurePath
+from pathlib import PurePath
+from importlib import resources
 
 from ...logic.settings import ItemSettings
 from ...logic.tag_loader import load_tags
@@ -47,7 +48,7 @@ class DragDropTableWidget(QTableWidget):
         self._initial_columns = False
         QTimer.singleShot(0, self.set_equal_column_widths)
 
-        logo = Path(__file__).resolve().parents[2] / "favicon.png"
+        logo = resources.files("mic_renamer") / "favicon.png"
         self.setStyleSheet(
             f"QTableWidget::viewport{{background-image:url('{logo.as_posix()}');"
             "background-repeat:no-repeat;background-position:center;}}"


### PR DESCRIPTION
## Summary
- ensure `defaults.yaml` is located via `importlib.resources` when running from a PyInstaller build
- load bundled resources (favicon and tags) via `importlib.resources`

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: `ImportError: libEGL.so.1: cannot open shared object file`)*

------
https://chatgpt.com/codex/tasks/task_e_68526c5749308326b8ae988bf9fcf9ff