### PR TITLE
Fix defaults loading without extra PyInstaller data

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,13 @@ print(get_usage_path())
 ## Building a Standalone Executable
 
 You can bundle the application into a single executable using
-[PyInstaller](https://pyinstaller.org/):
+[PyInstaller](https://pyinstaller.org/). The provided ``mic_renamer.spec`` file
+ensures that required data files like ``defaults.yaml`` and ``tags.json`` are
+included in the build:
 
 ```bash
 pip install pyinstaller
-pyinstaller --onefile -n mic-renamer mic_renamer/__main__.py
+pyinstaller --onefile mic_renamer.spec
 ```
 
 The resulting executable is written to the ``dist`` directory.

--- a/mic_renamer/__main__.py
+++ b/mic_renamer/__main__.py
@@ -1,4 +1,8 @@
-from .app import Application
+"""Application entry point for running as a script or packaged executable."""
+
+# Use an absolute import so the module works when executed directly
+# (e.g. when bundled with PyInstaller).
+from mic_renamer.app import Application
 
 
 def main() -> int:

--- a/mic_renamer/app.py
+++ b/mic_renamer/app.py
@@ -3,7 +3,7 @@ from PySide6.QtWidgets import QApplication
 from PySide6.QtGui import QIcon
 from PySide6.QtCore import Qt
 import sys
-from pathlib import Path
+from importlib import resources
 
 from .ui.main_window import RenamerApp
 from .utils.state_manager import StateManager
@@ -20,7 +20,7 @@ class Application:
         except Exception:
             pass
         self.app = QApplication(sys.argv)
-        logo = Path(__file__).resolve().parents[1] / "favicon.png"
+        logo = resources.files("mic_renamer") / "favicon.png"
         if logo.is_file():
             self.app.setWindowIcon(QIcon(str(logo)))
         # create config files on first run

--- a/mic_renamer/config/config_manager.py
+++ b/mic_renamer/config/config_manager.py
@@ -2,6 +2,36 @@
 from __future__ import annotations
 
 from pathlib import Path
+from importlib import resources
+
+# Fallback defaults used when the bundled YAML file is missing. This ensures
+# PyInstaller builds still work even if the data file was not included.
+DEFAULTS_YAML = """
+accepted_extensions:
+  - .jpg
+  - .jpeg
+  - .png
+  - .gif
+  - .bmp
+  - .heic
+  - .mp4
+  - .avi
+  - .mov
+  - .mkv
+  - .heic
+language: en
+tags_file: tags.json
+tag_usage_file: tag_usage.json
+last_project_number: ""
+tag_panel_visible: false
+default_save_directory: ""
+compression_max_size_kb: 2048
+compression_quality: 95
+compression_reduce_resolution: true
+compression_resize_only: false
+compression_max_width: 0
+compression_max_height: 0
+"""
 import yaml
 
 from ..utils.path_utils import get_config_dir
@@ -14,7 +44,8 @@ class ConfigManager:
         self.config_dir = get_config_dir()
         self.config_file = Path(self.config_dir) / "app_settings.yaml"
         self._config: dict | None = None
-        self.defaults_path = Path(__file__).with_name("defaults.yaml")
+        # load defaults via importlib.resources so PyInstaller bundles work
+        self.defaults_path = resources.files(__package__) / "defaults.yaml"
 
     def load(self) -> dict:
         """Load configuration from disk merging with defaults."""
@@ -26,7 +57,11 @@ class ConfigManager:
                 data = yaml.safe_load(self.config_file.read_text()) or {}
             except Exception:
                 data = {}
-        defaults = yaml.safe_load(self.defaults_path.read_text())
+        try:
+            defaults_text = self.defaults_path.read_text()
+        except FileNotFoundError:
+            defaults_text = DEFAULTS_YAML
+        defaults = yaml.safe_load(defaults_text)
         # ensure default path for the tags file in user config directory
         defaults.setdefault("tags_file", str(Path(get_config_dir()) / "tags.json"))
         # default path for tag usage statistics
@@ -51,7 +86,11 @@ class ConfigManager:
             self._config = cfg
         cfg = cfg or self._config
         if cfg is None:
-            cfg = yaml.safe_load(self.defaults_path.read_text())
+            try:
+                cfg_text = self.defaults_path.read_text()
+            except FileNotFoundError:
+                cfg_text = DEFAULTS_YAML
+            cfg = yaml.safe_load(cfg_text)
         Path(self.config_dir).mkdir(parents=True, exist_ok=True)
         with open(self.config_file, "w", encoding="utf-8") as fh:
             yaml.safe_dump(cfg, fh)
@@ -67,7 +106,11 @@ class ConfigManager:
 
     def restore_defaults(self) -> dict:
         """Overwrite config file with bundled defaults."""
-        defaults = yaml.safe_load(self.defaults_path.read_text())
+        try:
+            defaults_text = self.defaults_path.read_text()
+        except FileNotFoundError:
+            defaults_text = DEFAULTS_YAML
+        defaults = yaml.safe_load(defaults_text)
         defaults.setdefault("tags_file", str(Path(get_config_dir()) / "tags.json"))
         defaults.setdefault("tag_usage_file", str(Path(get_config_dir()) / "tag_usage.json"))
         defaults.setdefault("default_save_directory", str(get_config_dir()))

--- a/mic_renamer/logic/tag_loader.py
+++ b/mic_renamer/logic/tag_loader.py
@@ -1,12 +1,55 @@
 import json
 import os
 from pathlib import Path
+from importlib import resources
+
+# Fallback tags used when the bundled JSON file cannot be located. This is
+# primarily for cases where PyInstaller is executed without including the data
+# files.
+BUNDLED_TAGS_JSON = """{
+  \"AU\": {\"en\": \"Autoclave\", \"de\": \"Autoclave\"},
+  \"AU_DO\": {\"en\": \"Autoclave door\", \"de\": \"Autoclave door\"},
+  \"AU_INS\": {\"en\": \"Autoclave insulation\", \"de\": \"Autoclave insulation\"},
+  \"BO\": {\"en\": \"Bogie, trolley, drive\", \"de\": \"Bogie, trolley, drive\"},
+  \"BR\": {\"en\": \"Bridge ( rail / air caster)\", \"de\": \"Bridge ( rail / air caster)\"},
+  \"CS\": {\"en\": \"Cooling system ; cooling tower etc.\", \"de\": \"Cooling system ; cooling tower etc.\"},
+  \"CTR\": {\"en\": \"Control system general\", \"de\": \"Control system general\"},
+  \"CTR_AU\": {\"en\": \"Control autoclave ; door\", \"de\": \"Control autoclave ; door\"},
+  \"CTR_CU\": {\"en\": \"Control collecting unit\", \"de\": \"Control collecting unit\"},
+  \"CTR_FU\": {\"en\": \"Control feeding unit (pit box)\", \"de\": \"Control feeding unit (pit box)\"},
+  \"CTR_VU\": {\"en\": \"Control vacuum unit\", \"de\": \"Control vacuum unit\"},
+  \"CU\": {\"en\": \"Collecting unit\", \"de\": \"Collecting unit\"},
+  \"CU_VU\": {\"en\": \"Collecting & vacuum unit assembled and shown in total on the picture\", \"de\": \"Collecting & vacuum unit assembled and shown in total on the picture\"},
+  \"DU\": {\"en\": \"Distillation unit\", \"de\": \"Distillation unit\"},
+  \"EXP\": {\"en\": \"Expansion tank\", \"de\": \"Expansion tank\"},
+  \"FU\": {\"en\": \"Feeding unit\", \"de\": \"Feeding unit\"},
+  \"HS\": {\"en\": \"Heating system ( central)\", \"de\": \"Heating system ( central)\"},
+  \"HU_AU\": {\"en\": \"Heating unit for autoclave\", \"de\": \"Heating unit for autoclave\"},
+  \"HU_FU\": {\"en\": \"Heating unit for feeding unit\", \"de\": \"Heating unit for feeding unit\"},
+  \"HYD\": {\"en\": \"Hydraulic\", \"de\": \"Hydraulic\"},
+  \"INS\": {\"en\": \"Instruments\", \"de\": \"Instruments\"},
+  \"ISO\": {\"en\": \"Iso static press\", \"de\": \"Iso static press\"},
+  \"JET\": {\"en\": \"JET evaporator\", \"de\": \"JET evaporator\"},
+  \"N2\": {\"en\": \"Nitrogen\", \"de\": \"Nitrogen\"},
+  \"PG\": {\"en\": \"piping general, vacuum , solvent, air, N2, water , brine, oil,\", \"de\": \"piping general, vacuum , solvent, air, N2, water , brine, oil,\"},
+  \"PH\": {\"en\": \"Piping heating only for heat carrier oil circuit\", \"de\": \"Piping heating only for heat carrier oil circuit\"},
+  \"PIT\": {\"en\": \"Pit & foundation\", \"de\": \"Pit & foundation\"},
+  \"PLANT\": {\"en\": \"General plant overview pictures\", \"de\": \"General plant overview pictures\"},
+  \"SITE\": {\"en\": \"General site pictures showing also surrounding of plant, especially before installation\", \"de\": \"General site pictures showing also surrounding of plant, especially before installation\"},
+  \"SS\": {\"en\": \"Storage system, solvent, water, oil,\", \"de\": \"Storage system, solvent, water, oil,\"},
+  \"STAFF\": {\"en\": \"Staff pictures\", \"de\": \"Staff pictures\"},
+  \"ST_PL\": {\"en\": \"Stairs, ladders & platforms\", \"de\": \"Stairs, ladders & platforms\"},
+  \"TOOL\": {\"en\": \"Tools for ISO press\", \"de\": \"Tools for ISO press\"},
+  \"VC\": {\"en\": \"Vacuum connection\", \"de\": \"Vacuum connection\"},
+  \"VU\": {\"en\": \"Vacuum unit\", \"de\": \"Vacuum unit\"},
+  \"WIRE\": {\"en\": \"wiring and pneumatic\", \"de\": \"wiring and pneumatic\"}
+}"""
 
 from .. import config_manager
 from ..utils.path_utils import get_config_dir
 
 DEFAULT_TAGS_FILE = Path(get_config_dir()) / "tags.json"
-BUNDLED_TAGS_FILE = Path(__file__).resolve().parent.parent / "config" / "tags.json"
+BUNDLED_TAGS_FILE = resources.files("mic_renamer.config") / "tags.json"
 
 CONFIG_TAGS_FILE = config_manager.get("tags_file")
 
@@ -27,18 +70,23 @@ def _load_raw(file_path: str | None = None) -> dict:
                 path.write_text(BUNDLED_TAGS_FILE.read_text(), encoding="utf-8")
             except Exception:
                 pass
-    if not path.is_file():
-        path = BUNDLED_TAGS_FILE
-    if not path.is_file():
-        return {}
+    if path.is_file():
+        try:
+            with path.open("r", encoding="utf-8") as f:
+                data = json.load(f)
+            if isinstance(data, dict):
+                return data
+        except Exception:
+            pass
+    # Fallback to bundled file within the package or the built-in JSON string
     try:
-        with path.open("r", encoding="utf-8") as f:
-            data = json.load(f)
-        if isinstance(data, dict):
-            return data
+        data = json.loads(BUNDLED_TAGS_FILE.read_text())
     except Exception:
-        pass
-    return {}
+        try:
+            data = json.loads(BUNDLED_TAGS_JSON)
+        except Exception:
+            data = {}
+    return data if isinstance(data, dict) else {}
 
 def load_tags(file_path: str | None = None, language: str | None = None) -> dict:
     """Return tags for the requested language.
@@ -69,6 +117,9 @@ def restore_default_tags() -> None:
         DEFAULT_TAGS_FILE.parent.mkdir(parents=True, exist_ok=True)
         DEFAULT_TAGS_FILE.write_text(BUNDLED_TAGS_FILE.read_text(), encoding="utf-8")
     except Exception:
-        pass
+        try:
+            DEFAULT_TAGS_FILE.write_text(BUNDLED_TAGS_JSON, encoding="utf-8")
+        except Exception:
+            pass
 
 

--- a/mic_renamer/ui/panels/file_table.py
+++ b/mic_renamer/ui/panels/file_table.py
@@ -10,7 +10,8 @@ from PySide6.QtWidgets import (
 from PySide6.QtGui import QColor
 # Corrected import: QItemSelectionModel and QItemSelection come from QtCore, not QtWidgets
 from PySide6.QtCore import Qt, QTimer, QItemSelectionModel, QItemSelection
-from pathlib import Path, PurePath
+from pathlib import PurePath
+from importlib import resources
 
 from ...logic.settings import ItemSettings
 from ...logic.tag_loader import load_tags
@@ -47,7 +48,7 @@ class DragDropTableWidget(QTableWidget):
         self._initial_columns = False
         QTimer.singleShot(0, self.set_equal_column_widths)
 
-        logo = Path(__file__).resolve().parents[2] / "favicon.png"
+        logo = resources.files("mic_renamer") / "favicon.png"
         self.setStyleSheet(
             f"QTableWidget::viewport{{background-image:url('{logo.as_posix()}');"
             "background-repeat:no-repeat;background-position:center;}}"


### PR DESCRIPTION
## Summary
- bundle fallback defaults and tags in code to avoid missing files in PyInstaller builds
- point build instructions to the provided `mic_renamer.spec` so required data is included

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: `ImportError: libEGL.so.1`)*

------
https://chatgpt.com/codex/tasks/task_e_68526c5749308326b8ae988bf9fcf9ff