### PR TITLE
Add icon option and adjust table appearance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 __pycache__/
+
+# Icon file
+favicon.ico

--- a/README.md
+++ b/README.md
@@ -60,3 +60,17 @@ pyinstaller --onefile mic_renamer/__main__.py
 # or
 pyinstaller mic_renamer_onefile.spec
 ```
+
+### Custom Executable Icon
+
+The repository only bundles ``favicon.png``. To give the generated executable a
+custom icon, first convert this image to ``favicon.ico`` and include it in the
+build. The provided spec files already reference ``favicon.ico``:
+
+```bash
+from PIL import Image
+Image.open("favicon.png").save("favicon.ico")
+pyinstaller mic_renamer.spec
+```
+
+You can also pass ``--icon favicon.ico`` when invoking PyInstaller directly.

--- a/mic_renamer.spec
+++ b/mic_renamer.spec
@@ -15,7 +15,8 @@ a = Analysis(
     binaries=[],
     datas=[('mic_renamer/config/defaults.yaml', 'mic_renamer/config'),
            ('mic_renamer/config/tags.json', 'mic_renamer/config'),
-           ('favicon.png', '.')],
+           ('favicon.png', '.'),
+           ('favicon.ico', '.')],
     hiddenimports=hiddenimports,
     hookspath=[],
     runtime_hooks=[],
@@ -37,6 +38,7 @@ exe = EXE(
     strip=False,
     upx=True,
     console=False,
+    icon='favicon.ico',
 )
 coll = COLLECT(
     exe,

--- a/mic_renamer/ui/panels/file_table.py
+++ b/mic_renamer/ui/panels/file_table.py
@@ -1,4 +1,5 @@
 """Table widget with drag and drop support."""
+
 import os
 from PySide6.QtWidgets import (
     QTableWidget,
@@ -7,10 +8,10 @@ from PySide6.QtWidgets import (
     QApplication,
     QAbstractItemView,
 )
-from PySide6.QtGui import QColor
-# Corrected import: QItemSelectionModel and QItemSelection come from QtCore, not QtWidgets
+from PySide6.QtGui import QPalette
+
+# QItemSelectionModel and QItemSelection are in QtCore, not QtWidgets
 from PySide6.QtCore import Qt, QTimer, QItemSelectionModel, QItemSelection
-from pathlib import PurePath
 from importlib import resources
 
 from ...logic.settings import ItemSettings
@@ -28,7 +29,9 @@ class DragDropTableWidget(QTableWidget):
         self._updating_checks = False
         self.mode = "normal"
         self.setColumnCount(5)
-        self.setHorizontalHeaderLabels(["", "Filename", "Tags", "Date", "Suffix"])
+        self.setHorizontalHeaderLabels(
+            ["", "Filename", "Tags", "Date", "Suffix"]
+        )
         header = self.horizontalHeader()
         header.setSectionResizeMode(0, QHeaderView.ResizeToContents)
         header.setSectionResizeMode(1, QHeaderView.Interactive)
@@ -50,19 +53,26 @@ class DragDropTableWidget(QTableWidget):
         QTimer.singleShot(0, self.set_equal_column_widths)
 
         logo = resources.files("mic_renamer") / "favicon.png"
-        self.setStyleSheet(
-            f"QTableWidget::viewport{{background-image:url('{logo.as_posix()}');"
-            "background-repeat:no-repeat;background-position:center;}}"
+        style = (
+            "QTableWidget::viewport{"
+            f"background-image:url('{logo.as_posix()}');"
+            "background-repeat:no-repeat;"
+            "background-position:center;}"
         )
+        self.setStyleSheet(style)
 
     def set_mode(self, mode: str) -> None:
         """Switch table headers for the given mode."""
         self.mode = mode
         if mode == "position":
-            self.setHorizontalHeaderLabels(["", "Filename", "Pos", "Date", "Suffix"])
+            self.setHorizontalHeaderLabels(
+                ["", "Filename", "Pos", "Date", "Suffix"]
+            )
             self.setColumnHidden(3, True)
         else:
-            self.setHorizontalHeaderLabels(["", "Filename", "Tags", "Date", "Suffix"])
+            self.setHorizontalHeaderLabels(
+                ["", "Filename", "Tags", "Date", "Suffix"]
+            )
             self.setColumnHidden(3, False)
         for row in range(self.rowCount()):
             item1 = self.item(row, 1)
@@ -161,8 +171,9 @@ class DragDropTableWidget(QTableWidget):
             check_item.setCheckState(Qt.Unchecked)
             fname_item = QTableWidgetItem(os.path.basename(path))
             fname_item.setData(Qt.UserRole, path)
-            fname_item.setBackground(QColor(30, 30, 30))
-            fname_item.setForeground(QColor(220, 220, 220))
+            palette = QApplication.palette()
+            fname_item.setBackground(palette.color(QPalette.Base))
+            fname_item.setForeground(palette.color(QPalette.Text))
 
             tags = set()
             try:
@@ -171,7 +182,13 @@ class DragDropTableWidget(QTableWidget):
                 tags = set()
             date = get_capture_date(path)
             size_bytes = os.path.getsize(path)
-            settings = ItemSettings(path, tags=tags, date=date, size_bytes=size_bytes, compressed_bytes=size_bytes)
+            settings = ItemSettings(
+                path,
+                tags=tags,
+                date=date,
+                size_bytes=size_bytes,
+                compressed_bytes=size_bytes,
+            )
             fname_item.setData(ROLE_SETTINGS, settings)
 
             tags_item = QTableWidgetItem(",".join(sorted(tags)))
@@ -217,9 +234,17 @@ class DragDropTableWidget(QTableWidget):
                 if item.checkState() == Qt.Checked
                 else QItemSelectionModel.Deselect
             )
-            self.selectionModel().select(selection, command | QItemSelectionModel.Rows)
+            self.selectionModel().select(
+                selection, command | QItemSelectionModel.Rows
+            )
         else:
             if item.checkState() == Qt.Checked:
-                self.selectionModel().select(index, QItemSelectionModel.Select | QItemSelectionModel.Rows)
+                self.selectionModel().select(
+                    index,
+                    QItemSelectionModel.Select | QItemSelectionModel.Rows,
+                )
             else:
-                self.selectionModel().select(index, QItemSelectionModel.Deselect | QItemSelectionModel.Rows)
+                self.selectionModel().select(
+                    index,
+                    QItemSelectionModel.Deselect | QItemSelectionModel.Rows,
+                )

--- a/mic_renamer_onefile.spec
+++ b/mic_renamer_onefile.spec
@@ -15,7 +15,8 @@ a = Analysis(
     binaries=[],
     datas=[('mic_renamer/config/defaults.yaml', 'mic_renamer/config'),
            ('mic_renamer/config/tags.json', 'mic_renamer/config'),
-           ('favicon.png', '.')],
+           ('favicon.png', '.'),
+           ('favicon.ico', '.')],
     hiddenimports=hiddenimports,
     hookspath=[],
     runtime_hooks=[],
@@ -40,4 +41,5 @@ exe = EXE(
     upx=True,
     console=False,
     runtime_tmpdir=None,
+    icon='favicon.ico',
 )

--- a/tests/test_tag_apply.py
+++ b/tests/test_tag_apply.py
@@ -5,6 +5,7 @@ from PySide6.QtCore import Qt
 
 from mic_renamer.ui.main_window import RenamerApp, ROLE_SETTINGS
 
+
 @pytest.fixture(scope="module")
 def app():
     os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
@@ -14,9 +15,11 @@ def app():
     return app
 
 
-def test_checkbox_applies_tag(app):
+def test_checkbox_applies_tag(app, tmp_path):
+    img = tmp_path / "test.jpg"
+    img.write_bytes(b"x")
     win = RenamerApp()
-    win.table_widget.add_paths(["/tmp/test.jpg"])
+    win.table_widget.add_paths([str(img)])
     win.table_widget.selectRow(0)
     code = next(iter(win.tag_panel.checkbox_map))
     win.on_tag_toggled(code, Qt.Checked)
@@ -27,7 +30,7 @@ def test_checkbox_applies_tag(app):
     assert code in settings.tags
 
 
-def test_existing_tags_detected(app, monkeypatch):
+def test_existing_tags_detected(app, monkeypatch, tmp_path):
     tags = {"A": "Alpha", "B": "Beta"}
     monkeypatch.setattr(
         "mic_renamer.logic.tag_loader.load_tags",
@@ -37,8 +40,10 @@ def test_existing_tags_detected(app, monkeypatch):
         "mic_renamer.ui.panels.file_table.load_tags",
         lambda: tags,
     )
+    img = tmp_path / "image_A_B.jpg"
+    img.write_bytes(b"x")
     win = RenamerApp()
-    win.table_widget.add_paths(["/tmp/image_A_B.jpg"])
+    win.table_widget.add_paths([str(img)])
     win.table_widget.selectRow(0)
     cell_text = win.table_widget.item(0, 2).text()
     assert cell_text == "A,B"
@@ -48,4 +53,3 @@ def test_existing_tags_detected(app, monkeypatch):
     win.on_table_selection_changed()
     assert win.tag_panel.checkbox_map["A"].checkState() == Qt.Checked
     assert win.tag_panel.checkbox_map["B"].checkState() == Qt.Checked
-


### PR DESCRIPTION
## Summary
- update spec files to bundle a favicon.ico
- document how to build an exe with a custom icon
- adjust file table colors to follow the active palette
- create favicon.ico from favicon.png
- fix tests to use temporary images
- remove the binary favicon.ico and ignore it
- tweak FileTable style to satisfy flake8

## Testing
- `flake8 mic_renamer/ui/panels/file_table.py tests/test_tag_apply.py`
- `pytest tests/test_tag_apply.py::test_checkbox_applies_tag -q` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_6852a5d83dc08326ad10571174b57657