### PR TITLE
Improve README build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Photo/Video Renamer
+# Mic Renamer
 
-A desktop application to rename photos and videos using project numbers, tags and optional suffixes.
+A cross-platform desktop tool to rename photos and videos using project numbers, tag codes and optional suffixes. The UI is built with PySide6.
 
 ## Setup
 
@@ -16,14 +16,13 @@ A desktop application to rename photos and videos using project numbers, tags an
    python -m mic_renamer
    ```
 
-Configuration files are stored in the user specific configuration directory
-(e.g. `~/.config/mic_renamer` on Linux). Set the `RENAMER_CONFIG_DIR`
-environment variable to override this location. Defaults are bundled in
-`mic_renamer/config/defaults.yaml` and will be merged with your custom
-configuration at startup. A default `tags.json` file containing available tag
-codes is copied to the configuration directory on first run if it does not
-already exist. The application also remembers the last used project number so it
-is restored on the next launch.
+Configuration files are stored in a user specific directory (for example
+`~/.config/mic_renamer` on Linux). Set the `RENAMER_CONFIG_DIR` environment
+variable if you want them somewhere else, e.g. on your `D:` drive. Defaults
+ship with the project in `mic_renamer/config/defaults.yaml` and are merged with
+your configuration on start. A `tags.json` file is copied to the configuration
+folder the first time the program runs so you can adapt it to your needs. The
+application also remembers the last used project number.
 
 Tag usage statistics are written to ``tag_usage.json`` in the same
 configuration directory. You can discover the full path programmatically:
@@ -35,31 +34,31 @@ print(get_usage_path())
 
 ## Building a Standalone Executable
 
+The repository contains three spec files for [PyInstaller](https://pyinstaller.org/):
 
-You can bundle the application into a single executable using
-[PyInstaller](https://pyinstaller.org/). The provided ``mic_renamer.spec`` file
-ensures that required data files like ``defaults.yaml`` and ``tags.json`` are
-included in the build:
+* ``mic_renamer.spec`` – builds a folder style distribution in ``dist/mic-renamer``.
+  The resulting ``mic-renamer.exe`` runs without opening a console and includes
+  the icon if ``favicon.png``/``favicon.ico`` are present.
+* ``mic_renamer_onefile.spec`` – like above but produces a single file executable.
+* ``mic-renamer.spec`` – a minimal spec kept for reference. You normally do not
+  need this one.
+
+Use one of the first two spec files from the repository root:
 
 ```bash
 pip install pyinstaller
 
-pyinstaller --onefile mic_renamer.spec    
-or
-pyinstaller mic_renamer.spec 
+# folder build
+pyinstaller mic_renamer.spec
 
-```
-
-The resulting build directory is written to ``dist/mic-renamer``.
-
-If you prefer a single-file executable, run PyInstaller directly on the entry
-module or use the provided ``mic_renamer_onefile.spec``:
-
-```bash
-pyinstaller --onefile mic_renamer/__main__.py
-# or
+# single file build
 pyinstaller mic_renamer_onefile.spec
+
 ```
+
+The resulting build directory is written to ``dist/mic-renamer``. If you prefer
+a single-file executable you can call PyInstaller directly on the entry module
+and pass ``--onefile``.
 
 ### Custom Executable Icon
 
@@ -74,20 +73,19 @@ Image.open("my_icon.png").save("favicon.png")
 Image.open("my_icon.png").save("favicon.ico")
 ```
 
-After placing the icons, run the build using the provided spec file:
+After placing the icons, build the executable. The spec files automatically
+pick up ``favicon.ico`` when present. You can also pass ``--icon`` manually:
 
 ```bash
-pyinstaller mic_renamer.spec
+pyinstaller --icon favicon.ico mic_renamer.spec
 ```
 
-To specify the icon via command-line options instead, invoke PyInstaller
-directly on the entry module:
+If you run PyInstaller directly on the entry module, pass ``--noconsole`` to
+avoid an extra terminal window:
 
 ```bash
-pyinstaller --icon favicon.ico mic_renamer/__main__.py
+pyinstaller --noconsole --icon favicon.ico mic_renamer/__main__.py
 ```
-
-Alternatively, pass ``--icon`` when invoking PyInstaller directly.
 
 Some antivirus tools flag UPX-compressed executables. If this occurs, disable
 compression by passing ``--noupx`` or editing the spec files to set


### PR DESCRIPTION
## Summary
- clarify configuration options in README
- explain when to use the provided PyInstaller spec files
- add notes on icons and hiding the console window

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_6853e72e857883269c6cd241173cf8b2