### PR TITLE
Improve Windows compatibility and cleanup

### DIFF
--- a/mic_renamer/config/__init__.py
+++ b/mic_renamer/config/__init__.py
@@ -1,1 +1,1 @@
-from .config_manager import ConfigManager
+

--- a/mic_renamer/logic/tag_service.py
+++ b/mic_renamer/logic/tag_service.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import os
 import re
-from typing import Iterable, Set
+from typing import Iterable
 
 
 def extract_tags_from_name(name: str, valid_tags: Iterable[str]) -> set[str]:

--- a/mic_renamer/ui/compression_dialog.py
+++ b/mic_renamer/ui/compression_dialog.py
@@ -7,7 +7,6 @@ from PySide6.QtWidgets import (
     QTableWidgetItem,
     QDialogButtonBox,
 )
-from PySide6.QtCore import Qt
 import os
 
 from ..logic.image_compressor import ImageCompressor

--- a/mic_renamer/ui/main_window.py
+++ b/mic_renamer/ui/main_window.py
@@ -1,15 +1,14 @@
 import os
 import re
-from pathlib import Path
 from PySide6.QtWidgets import (
-    QWidget, QSplitter, QHBoxLayout, QVBoxLayout, QGridLayout,
+    QWidget, QHBoxLayout, QVBoxLayout, QGridLayout,
     QPushButton, QSlider, QFileDialog, QMessageBox, QToolBar,
     QApplication, QLabel, QComboBox,
-    QProgressDialog, QDialog, QDialogButtonBox, QAbstractItemView,
-    QHeaderView, QStyle, QTableWidget, QTableWidgetItem
+    QProgressDialog, QDialog, QDialogButtonBox,
+    QStyle, QTableWidget, QTableWidgetItem
 )
 from PySide6.QtGui import QColor, QAction, QIcon, QPixmap, QPainter, QFont
-from PySide6.QtCore import Qt, QTimer, QItemSelectionModel, QItemSelection
+from PySide6.QtCore import Qt, QTimer
 
 from .. import config_manager
 from ..utils.i18n import tr, set_language
@@ -23,7 +22,6 @@ from .panels import (
 from .rename_options_dialog import RenameOptionsDialog
 from .project_number_input import ProjectNumberInput
 from ..logic.settings import ItemSettings
-from ..logic.image_compressor import ImageCompressor
 from ..logic.renamer import Renamer
 from ..logic.tag_usage import increment_tags
 from ..logic.undo_manager import UndoManager

--- a/mic_renamer/ui/panels/compression_settings.py
+++ b/mic_renamer/ui/panels/compression_settings.py
@@ -1,8 +1,6 @@
 """Panel for configuring image compression settings."""
 from __future__ import annotations
 
-from pathlib import Path
-
 from PySide6.QtWidgets import (
     QWidget,
     QFormLayout,

--- a/mic_renamer/ui/panels/tag_panel.py
+++ b/mic_renamer/ui/panels/tag_panel.py
@@ -1,7 +1,7 @@
 """Panel showing available tags as checkboxes."""
 from PySide6.QtWidgets import QWidget, QGridLayout, QVBoxLayout, QLabel
 from ..components import EnterToggleCheckBox
-from PySide6.QtCore import Qt, Signal
+from PySide6.QtCore import Signal
 import logging
 
 from ...logic.tag_loader import load_tags

--- a/mic_renamer/ui/rename_options_dialog.py
+++ b/mic_renamer/ui/rename_options_dialog.py
@@ -2,10 +2,9 @@
 from __future__ import annotations
 
 from PySide6.QtWidgets import (
-    QDialog, QVBoxLayout, QHBoxLayout, QLabel, QRadioButton,
+    QDialog, QVBoxLayout, QHBoxLayout, QRadioButton,
     QLineEdit, QPushButton, QFileDialog, QDialogButtonBox
 )
-from PySide6.QtCore import Qt
 
 from .. import config_manager
 from ..utils.i18n import tr

--- a/mic_renamer/ui/settings_dialog.py
+++ b/mic_renamer/ui/settings_dialog.py
@@ -3,7 +3,6 @@ from PySide6.QtWidgets import (
     QDialogButtonBox, QComboBox, QTableWidget, QTableWidgetItem,
     QPushButton, QTabWidget, QWidget
 )
-from PySide6.QtCore import Qt
 
 from ..utils.state_manager import StateManager
 

--- a/mic_renamer/utils/file_utils.py
+++ b/mic_renamer/utils/file_utils.py
@@ -2,11 +2,23 @@
 
 import os
 
+
+def _samefile(path1: str, path2: str) -> bool:
+    """Return True if both paths refer to the same file.
+
+    Falls back to a case-insensitive comparison on platforms lacking
+    ``os.path.samefile`` (e.g. Windows without `stat` support).
+    """
+    try:
+        return os.path.samefile(path1, path2)
+    except Exception:
+        return os.path.abspath(os.path.normcase(path1)) == os.path.abspath(os.path.normcase(path2))
+
 def ensure_unique_name(candidate: str, original_path: str) -> str:
     base, ext = os.path.splitext(candidate)
     counter = 1
     new_path = candidate
-    while os.path.exists(new_path) and os.path.abspath(new_path) != os.path.abspath(original_path):
+    while os.path.exists(new_path) and not _samefile(new_path, original_path):
         new_path = f"{base}_{counter:03d}{ext}"
         counter += 1
     return new_path

--- a/mic_renamer/utils/meta_utils.py
+++ b/mic_renamer/utils/meta_utils.py
@@ -14,16 +14,16 @@ def get_capture_date(path: str | Path, date_format: str = "%y%m%d") -> str:
     """
     file_path = Path(path)
     try:
-        img = Image.open(file_path)
-        exif = img._getexif() or {}
-        tag_map = {ExifTags.TAGS.get(k): v for k, v in exif.items()}
-        dt = tag_map.get("DateTimeOriginal") or tag_map.get("DateTime")
-        if dt:
-            try:
-                dt_obj = datetime.strptime(str(dt), "%Y:%m:%d %H:%M:%S")
-                return dt_obj.strftime(date_format)
-            except Exception:
-                pass
+        with Image.open(file_path) as img:
+            exif = img._getexif() or {}
+            tag_map = {ExifTags.TAGS.get(k): v for k, v in exif.items()}
+            dt = tag_map.get("DateTimeOriginal") or tag_map.get("DateTime")
+            if dt:
+                try:
+                    dt_obj = datetime.strptime(str(dt), "%Y:%m:%d %H:%M:%S")
+                    return dt_obj.strftime(date_format)
+                except Exception:
+                    pass
     except Exception:
         pass
     try:


### PR DESCRIPTION
## Summary
- avoid case-sensitive path comparisons when generating unique file names
- close files when reading EXIF metadata
- drop unused imports across modules

## Testing
- `pyflakes mic_renamer`
- `vulture mic_renamer --min-confidence 80 --sort-by-size`
- `pytest -q` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_6855a5957e3083269340b1bbbde4c147