### PR TITLE
Add toolbar style preference

### DIFF
--- a/mic_renamer/config/config_manager.py
+++ b/mic_renamer/config/config_manager.py
@@ -24,6 +24,7 @@ tags_file: tags.json
 tag_usage_file: tag_usage.json
 last_project_number: ""
 tag_panel_visible: false
+toolbar_style: icons
 default_save_directory: ""
 compression_max_size_kb: 2048
 compression_quality: 95
@@ -77,6 +78,7 @@ class ConfigManager:
         defaults.setdefault("compression_resize_only", False)
         defaults.setdefault("compression_max_width", 0)
         defaults.setdefault("compression_max_height", 0)
+        defaults.setdefault("toolbar_style", "icons")
         self._config = {**defaults, **data}
         return self._config
 
@@ -120,6 +122,7 @@ class ConfigManager:
         defaults.setdefault("compression_resize_only", False)
         defaults.setdefault("compression_max_width", 0)
         defaults.setdefault("compression_max_height", 0)
+        defaults.setdefault("toolbar_style", "icons")
         self._config = defaults
         self.save(defaults)
         return defaults

--- a/mic_renamer/config/defaults.yaml
+++ b/mic_renamer/config/defaults.yaml
@@ -14,6 +14,7 @@ tags_file: tags.json
 tag_usage_file: tag_usage.json
 last_project_number: ""
 tag_panel_visible: false
+toolbar_style: icons
 default_save_directory: ""
 compression_max_size_kb: 2048
 compression_quality: 95

--- a/mic_renamer/ui/main_window.py
+++ b/mic_renamer/ui/main_window.py
@@ -130,6 +130,11 @@ class RenamerApp(QWidget):
 
     def setup_toolbar(self):
         tb = self.toolbar
+        style = config_manager.get("toolbar_style", "icons")
+        if style == "text":
+            tb.setToolButtonStyle(Qt.ToolButtonTextUnderIcon)
+        else:
+            tb.setToolButtonStyle(Qt.ToolButtonIconOnly)
         self.toolbar_actions = []
 
         act_add_files = QAction(resource_icon("file-plus.svg"), tr("add_files"), self)
@@ -220,6 +225,11 @@ class RenamerApp(QWidget):
             set_language(cfg.get("language", "en"))
             self.update_translations()
             self.rebuild_tag_checkboxes()
+            style = cfg.get("toolbar_style", "icons")
+            if style == "text":
+                self.toolbar.setToolButtonStyle(Qt.ToolButtonTextUnderIcon)
+            else:
+                self.toolbar.setToolButtonStyle(Qt.ToolButtonIconOnly)
 
     def save_last_project_number(self, text: str) -> None:
         config_manager.set("last_project_number", text.strip())

--- a/mic_renamer/ui/settings_dialog.py
+++ b/mic_renamer/ui/settings_dialog.py
@@ -1,7 +1,7 @@
 from PySide6.QtWidgets import (
     QDialog, QVBoxLayout, QHBoxLayout, QLabel, QLineEdit,
     QDialogButtonBox, QComboBox, QTableWidget, QTableWidgetItem,
-    QPushButton, QTabWidget, QWidget
+    QPushButton, QTabWidget, QWidget, QCheckBox
 )
 
 from ..utils.state_manager import StateManager
@@ -67,6 +67,12 @@ class SettingsDialog(QDialog):
         hl.addWidget(self.combo_lang)
         gen_layout.addLayout(hl)
 
+        self.chk_toolbar_text = QCheckBox(tr("use_text_menu"))
+        self.chk_toolbar_text.setChecked(
+            self.cfg.get("toolbar_style", "icons") == "text"
+        )
+        gen_layout.addWidget(self.chk_toolbar_text)
+
         gen_layout.addWidget(QLabel(tr("tags_label")))
         tags = load_tags(language=current_lang)
         self.tbl_tags = QTableWidget(len(tags), 2)
@@ -122,6 +128,9 @@ class SettingsDialog(QDialog):
         # save language
         self.cfg['language'] = self.combo_lang.currentText()
         self.cfg['default_save_directory'] = self.edit_save_dir.text().strip()
+        style = 'text' if self.chk_toolbar_text.isChecked() else 'icons'
+        self.cfg['toolbar_style'] = style
+        config_manager.set('toolbar_style', style)
         self.compression_panel.update_cfg()
         config_manager.save(self.cfg)
         # save tags for selected language
@@ -160,6 +169,9 @@ class SettingsDialog(QDialog):
         restore_default_tags()
         self.edit_ext.setText(", ".join(self.cfg.get("accepted_extensions", [])))
         self.edit_save_dir.setText(self.cfg.get('default_save_directory', ''))
+        self.chk_toolbar_text.setChecked(
+            self.cfg.get("toolbar_style", "icons") == "text"
+        )
         lang = self.cfg.get("language", "en")
         idx = self.combo_lang.findText(lang)
         if idx >= 0:

--- a/mic_renamer/utils/i18n.py
+++ b/mic_renamer/utils/i18n.py
@@ -57,6 +57,7 @@ TRANSLATIONS = {
         'remove_selected': 'Remove Selected',
         'config_path_label': 'Configuration folder',
         'default_save_dir_label': 'Default save directory',
+        'use_text_menu': 'Show text labels in toolbar',
         'use_original_directory': 'Use current folder?',
         'use_original_directory_msg': 'Save renamed files in their current folder?',
         'current_name': 'Current Name'
@@ -136,6 +137,7 @@ TRANSLATIONS = {
         , 'undo_done': 'Umbenennungen zurückgesetzt.'
         , 'config_path_label': 'Konfigurationsordner'
         , 'default_save_dir_label': 'Standard-Speicherordner'
+        , 'use_text_menu': 'Text in der Werkzeugleiste anzeigen'
         , 'use_original_directory': 'Aktuellen Ordner verwenden?'
         , 'use_original_directory_msg': 'Umbenannte Dateien im aktuellen Ordner speichern?'
         , 'mode_normal': 'Normal'


### PR DESCRIPTION
## Summary
- add `toolbar_style` to default configuration
- translate new setting label
- expose checkbox in Settings dialog to toggle toolbar style
- save toolbar style and apply in `setup_toolbar`

## Testing
- `pytest -q` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_6855c42eedfc83268218d9a0443a9059