### PR TITLE
Persist splitter sizes across sessions

### DIFF
--- a/mic_renamer/app.py
+++ b/mic_renamer/app.py
@@ -38,6 +38,9 @@ class Application:
         width = self.state.get("width", config_manager.get("window_width", 1200))
         height = self.state.get("height", config_manager.get("window_height", 800))
         self.window.resize(width, height)
+        sizes = self.state.get("splitter_sizes")
+        if sizes:
+            self.window.set_splitter_sizes(sizes)
 
     def run(self) -> int:
         """Start the Qt event loop."""

--- a/mic_renamer/ui/main_window.py
+++ b/mic_renamer/ui/main_window.py
@@ -48,8 +48,9 @@ class RenamerApp(QWidget):
 
         # no separate selected file display
 
-        splitter = QSplitter(Qt.Horizontal)
-        main_layout.addWidget(splitter)
+        # main splitter between preview and table
+        self.splitter = QSplitter(Qt.Horizontal)
+        main_layout.addWidget(self.splitter)
 
         viewer_widget = QWidget()
         viewer_layout = QVBoxLayout(viewer_widget)
@@ -90,8 +91,13 @@ class RenamerApp(QWidget):
         self._ignore_table_changes = False
         self.table_widget.itemChanged.connect(self.on_table_item_changed)
 
-        splitter.addWidget(viewer_widget)
-        splitter.addWidget(self.table_widget)
+        self.splitter.addWidget(viewer_widget)
+        self.splitter.addWidget(self.table_widget)
+
+        if self.state_manager:
+            sizes = self.state_manager.get("splitter_sizes")
+            if sizes:
+                self.splitter.setSizes(sizes)
 
         # Tag container spanning both columns with manual toggle
         self.tag_panel = TagPanel()
@@ -113,6 +119,11 @@ class RenamerApp(QWidget):
         self.table_widget.itemSelectionChanged.connect(self.on_table_selection_changed)
 
         self.update_translations()
+
+    def set_splitter_sizes(self, sizes: list[int] | None) -> None:
+        """Set the splitter sizes if a valid list is provided."""
+        if sizes:
+            self.splitter.setSizes(sizes)
 
     def toggle_tag_panel(self):
         visible = self.tag_panel.isVisible()
@@ -768,6 +779,7 @@ class RenamerApp(QWidget):
         if self.state_manager:
             self.state_manager.set("width", self.width())
             self.state_manager.set("height", self.height())
+            self.state_manager.set("splitter_sizes", self.splitter.sizes())
             self.state_manager.save()
         super().closeEvent(event)
 

--- a/tests/test_splitter_state.py
+++ b/tests/test_splitter_state.py
@@ -1,0 +1,44 @@
+import os
+import pytest
+from PySide6.QtWidgets import QApplication
+from mic_renamer.ui.main_window import RenamerApp
+
+
+class DummyState:
+    def __init__(self):
+        self.data = {}
+    def get(self, key, default=None):
+        return self.data.get(key, default)
+    def set(self, key, value):
+        self.data[key] = value
+    def save(self):
+        pass
+
+
+@pytest.fixture(scope="module")
+def app():
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+def test_splitter_state_persist(app):
+    state = DummyState()
+    win = RenamerApp(state_manager=state)
+    win.show()
+    app.processEvents()
+
+    win.splitter.setSizes([100, 200])
+    app.processEvents()
+    sizes = win.splitter.sizes()
+
+    win.close()
+    assert state.data["splitter_sizes"] == sizes
+
+    win2 = RenamerApp(state_manager=state)
+    win2.show()
+    app.processEvents()
+    assert win2.splitter.sizes() == sizes
+    win2.close()


### PR DESCRIPTION
## Summary
- remember the splitter state via `StateManager`
- restore splitter sizes when launching the app
- test persistence of splitter state

## Testing
- `PYTHONPATH=. pytest -vv tests/test_splitter_state.py`

------
https://chatgpt.com/codex/tasks/task_e_6855cded2b0883269f9ef42b679e0fed