### PR TITLE
Apply suffix change to selected rows

### DIFF
--- a/mic_renamer/ui/main_window.py
+++ b/mic_renamer/ui/main_window.py
@@ -477,8 +477,31 @@ class RenamerApp(QWidget):
             settings.position = item.text().strip()
             item.setToolTip(settings.position)
         elif col == 4:
-            settings.suffix = item.text().strip()
+            new_suffix = item.text().strip()
+            settings.suffix = new_suffix
             item.setToolTip(settings.suffix)
+            rows = getattr(self.table_widget, "_selection_before_edit", [])
+            for r in rows:
+                if r == row:
+                    continue
+                cell = self.table_widget.item(r, 4)
+                if not cell or cell.text().strip():
+                    continue
+                other_item0 = self.table_widget.item(r, 1)
+                other_settings: ItemSettings | None = (
+                    other_item0.data(ROLE_SETTINGS) if other_item0 else None
+                )
+                if other_settings is None:
+                    continue
+                self._ignore_table_changes = True
+                try:
+                    cell.setText(new_suffix)
+                finally:
+                    self._ignore_table_changes = False
+                cell.setToolTip(new_suffix)
+                other_settings.suffix = new_suffix
+                self.update_row_background(r, other_settings)
+            self.table_widget._selection_before_edit = []
         self.update_row_background(row, settings)
         if row in {idx.row() for idx in self.table_widget.selectionModel().selectedRows()}:
             self.on_table_selection_changed()

--- a/mic_renamer/ui/panels/file_table.py
+++ b/mic_renamer/ui/panels/file_table.py
@@ -48,6 +48,7 @@ class DragDropTableWidget(QTableWidget):
         self.verticalHeader().setDefaultSectionSize(24)
         self.itemSelectionChanged.connect(self.sync_check_column)
         self.itemChanged.connect(self.handle_item_changed)
+        self._selection_before_edit: list[int] = []
         self._initial_columns = False
         QTimer.singleShot(0, self.set_equal_column_widths)
 
@@ -248,3 +249,11 @@ class DragDropTableWidget(QTableWidget):
                     index,
                     QItemSelectionModel.Deselect | QItemSelectionModel.Rows,
                 )
+
+    def mousePressEvent(self, event):
+        index = self.indexAt(event.pos())
+        if index.isValid() and index.column() == 4:
+            self._selection_before_edit = [
+                idx.row() for idx in self.selectionModel().selectedRows()
+            ]
+        super().mousePressEvent(event)

--- a/tests/test_suffix_edit.py
+++ b/tests/test_suffix_edit.py
@@ -1,0 +1,50 @@
+import os
+import pytest
+from PySide6.QtWidgets import QApplication
+from PySide6.QtCore import QItemSelectionModel
+
+from mic_renamer.ui.main_window import RenamerApp
+
+
+@pytest.fixture(scope="module")
+def app():
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+def select_two_rows(table):
+    table.selectRow(0)
+    index = table.model().index(1, 0)
+    table.selectionModel().select(index, QItemSelectionModel.Select | QItemSelectionModel.Rows)
+
+
+def test_edit_suffix_updates_selected(app, tmp_path):
+    img1 = tmp_path / "one.jpg"
+    img2 = tmp_path / "two.jpg"
+    img1.write_bytes(b"x")
+    img2.write_bytes(b"y")
+    win = RenamerApp()
+    win.table_widget.add_paths([str(img1), str(img2)])
+    select_two_rows(win.table_widget)
+    win.table_widget._selection_before_edit = [0, 1]
+    win.table_widget.item(0, 4).setText("foo")
+    assert win.table_widget.item(0, 4).text() == "foo"
+    assert win.table_widget.item(1, 4).text() == "foo"
+
+
+def test_existing_suffix_unchanged(app, tmp_path):
+    img1 = tmp_path / "one.jpg"
+    img2 = tmp_path / "two.jpg"
+    img1.write_bytes(b"x")
+    img2.write_bytes(b"y")
+    win = RenamerApp()
+    win.table_widget.add_paths([str(img1), str(img2)])
+    win.table_widget.item(1, 4).setText("bar")
+    select_two_rows(win.table_widget)
+    win.table_widget._selection_before_edit = [0, 1]
+    win.table_widget.item(0, 4).setText("foo")
+    assert win.table_widget.item(0, 4).text() == "foo"
+    assert win.table_widget.item(1, 4).text() == "bar"


### PR DESCRIPTION
## Summary
- propagate suffix edits to other selected rows lacking a suffix
- remember selection prior to editing
- test suffix propagation logic

## Testing
- `pytest -q tests/test_suffix_edit.py` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_6855d3dd81e083268844843ed4a8d595