### PR TITLE
Update tag editing to handle multiple rows

### DIFF
--- a/mic_renamer/ui/main_window.py
+++ b/mic_renamer/ui/main_window.py
@@ -463,6 +463,28 @@ class RenamerApp(QWidget):
                 item.setText(text)
                 self._ignore_table_changes = False
             item.setToolTip(text)
+            rows = getattr(self.table_widget, "_selection_before_edit", [])
+            for r in rows:
+                if r == row:
+                    continue
+                cell = self.table_widget.item(r, 2)
+                if not cell or cell.text().strip():
+                    continue
+                other_item0 = self.table_widget.item(r, 1)
+                other_settings: ItemSettings | None = (
+                    other_item0.data(ROLE_SETTINGS) if other_item0 else None
+                )
+                if other_settings is None:
+                    continue
+                self._ignore_table_changes = True
+                try:
+                    cell.setText(text)
+                finally:
+                    self._ignore_table_changes = False
+                cell.setToolTip(text)
+                other_settings.tags = set(valid_tags)
+                self.update_row_background(r, other_settings)
+            self.table_widget._selection_before_edit = []
         elif self.rename_mode == MODE_NORMAL and col == 3:
             text = item.text().strip()
             if not re.fullmatch(r"\d{6}", text):

--- a/mic_renamer/ui/panels/file_table.py
+++ b/mic_renamer/ui/panels/file_table.py
@@ -252,8 +252,11 @@ class DragDropTableWidget(QTableWidget):
 
     def mousePressEvent(self, event):
         index = self.indexAt(event.pos())
-        if index.isValid() and index.column() == 4:
-            self._selection_before_edit = [
-                idx.row() for idx in self.selectionModel().selectedRows()
-            ]
+        if index.isValid():
+            if index.column() == 4 or (
+                index.column() == 2 and self.mode == "normal"
+            ):
+                self._selection_before_edit = [
+                    idx.row() for idx in self.selectionModel().selectedRows()
+                ]
         super().mousePressEvent(event)

--- a/tests/test_tag_edit.py
+++ b/tests/test_tag_edit.py
@@ -1,0 +1,72 @@
+import os
+import pytest
+from PySide6.QtWidgets import QApplication
+from PySide6.QtCore import QItemSelectionModel
+
+from mic_renamer.ui.main_window import RenamerApp, ROLE_SETTINGS
+
+
+@pytest.fixture(scope="module")
+def app():
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+def select_two_rows(table):
+    table.selectRow(0)
+    index = table.model().index(1, 0)
+    table.selectionModel().select(
+        index, QItemSelectionModel.Select | QItemSelectionModel.Rows
+    )
+
+
+def test_edit_tags_updates_selected(app, monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "mic_renamer.logic.tag_loader.load_tags", lambda: {"T": "Test"}
+    )
+    monkeypatch.setattr(
+        "mic_renamer.ui.panels.file_table.load_tags", lambda: {"T": "Test"}
+    )
+    img1 = tmp_path / "one.jpg"
+    img2 = tmp_path / "two.jpg"
+    img1.write_bytes(b"x")
+    img2.write_bytes(b"y")
+    win = RenamerApp()
+    win.table_widget.add_paths([str(img1), str(img2)])
+    select_two_rows(win.table_widget)
+    win.table_widget._selection_before_edit = [0, 1]
+    win.table_widget.item(0, 2).setText("T")
+    assert win.table_widget.item(0, 2).text() == "T"
+    assert win.table_widget.item(1, 2).text() == "T"
+    settings1 = win.table_widget.item(0, 1).data(ROLE_SETTINGS)
+    settings2 = win.table_widget.item(1, 1).data(ROLE_SETTINGS)
+    assert settings1.tags == {"T"}
+    assert settings2.tags == {"T"}
+
+
+def test_existing_tags_unchanged(app, monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "mic_renamer.logic.tag_loader.load_tags", lambda: {"T": "Test", "X": "X"}
+    )
+    monkeypatch.setattr(
+        "mic_renamer.ui.panels.file_table.load_tags", lambda: {"T": "Test", "X": "X"}
+    )
+    img1 = tmp_path / "one.jpg"
+    img2 = tmp_path / "two.jpg"
+    img1.write_bytes(b"x")
+    img2.write_bytes(b"y")
+    win = RenamerApp()
+    win.table_widget.add_paths([str(img1), str(img2)])
+    win.table_widget.item(1, 2).setText("X")
+    select_two_rows(win.table_widget)
+    win.table_widget._selection_before_edit = [0, 1]
+    win.table_widget.item(0, 2).setText("T")
+    assert win.table_widget.item(0, 2).text() == "T"
+    assert win.table_widget.item(1, 2).text() == "X"
+    settings1 = win.table_widget.item(0, 1).data(ROLE_SETTINGS)
+    settings2 = win.table_widget.item(1, 1).data(ROLE_SETTINGS)
+    assert settings1.tags == {"T"}
+    assert settings2.tags == {"X"}


### PR DESCRIPTION
## Summary
- propagate selected rows when editing tags directly in the table
- capture selected rows on tag cell edit
- add tests covering the multi-row tag editing behaviour

## Testing
- `python -m pytest tests/test_splitter_state.py -vv`

------
https://chatgpt.com/codex/tasks/task_e_6855d55ee6f08326b63d13183f544e8a