### PR TITLE
Add missing translations

### DIFF
--- a/mic_renamer/logic/renamer.py
+++ b/mic_renamer/logic/renamer.py
@@ -4,6 +4,8 @@ import os
 from collections import defaultdict
 from PySide6.QtWidgets import QMessageBox
 
+from ..utils.i18n import tr
+
 from .settings import ItemSettings, RenameConfig
 from ..utils.file_utils import ensure_unique_name
 from .tag_usage import increment_tags
@@ -73,7 +75,7 @@ class Renamer:
             except Exception as e:
                 QMessageBox.warning(
                     parent_widget,
-                    "Rename Failed",
+                    tr("rename_failed"),
                     f"Fehler beim Umbenennen:\n{orig}\n→ {new}\nError: {e}"
                 )
         if used_tags and self.mode == "normal":

--- a/mic_renamer/ui/main_window.py
+++ b/mic_renamer/ui/main_window.py
@@ -521,8 +521,11 @@ class RenamerApp(QWidget):
             valid_tags = {t for t in raw_tags if t in self.tag_panel.tags_info}
             invalid = raw_tags - valid_tags
             if invalid:
-                QMessageBox.warning(self, "Invalid Tags",
-                                    "Invalid tags: " + ", ".join(sorted(invalid)))
+                QMessageBox.warning(
+                    self,
+                    tr("invalid_tags_title"),
+                    tr("invalid_tags_msg").format(tags=", ".join(sorted(invalid)))
+                )
             settings.tags = valid_tags
             text = ",".join(sorted(valid_tags))
             if text != item.text():
@@ -555,7 +558,11 @@ class RenamerApp(QWidget):
         elif self.rename_mode == MODE_NORMAL and col == 3:
             text = item.text().strip()
             if not re.fullmatch(r"\d{6}", text):
-                QMessageBox.warning(self, "Invalid Date", "Date must be YYMMDD")
+                QMessageBox.warning(
+                    self,
+                    tr("invalid_date_title"),
+                    tr("invalid_date_msg"),
+                )
                 self._ignore_table_changes = True
                 item.setText(settings.date)
                 self._ignore_table_changes = False
@@ -791,7 +798,10 @@ class RenamerApp(QWidget):
         dlg.setWindowTitle(tr("preview_rename"))
         dlg_layout = QVBoxLayout(dlg)
         tbl = QTableWidget(len(table_mapping), 2, dlg)
-        tbl.setHorizontalHeaderLabels(["Current Name", "Proposed New Name"])
+        tbl.setHorizontalHeaderLabels([
+            tr("current_name"),
+            tr("proposed_new_name"),
+        ])
         tbl.verticalHeader().setVisible(False)
         tbl.setEditTriggers(QTableWidget.NoEditTriggers)
         tbl.setSelectionMode(QTableWidget.NoSelection)

--- a/mic_renamer/utils/i18n.py
+++ b/mic_renamer/utils/i18n.py
@@ -74,6 +74,10 @@ TRANSLATIONS = {
         , 'mode_position': 'Pos Mode Andi'
         , 'status_selected': '{current} of {total} selected'
         , 'status_loading': 'Loading...'
+        , 'invalid_tags_title': 'Invalid Tags'
+        , 'invalid_tags_msg': 'Invalid tags: {tags}'
+        , 'invalid_date_title': 'Invalid Date'
+        , 'invalid_date_msg': 'Date must be YYMMDD'
     },
     'de': {
         'app_title': 'Micavac Renamer',
@@ -148,6 +152,10 @@ TRANSLATIONS = {
         , 'mode_position': 'Pos Modus Andi'
         , 'status_selected': '{current} von {total} ausgewählt'
         , 'status_loading': 'Laden...'
+        , 'invalid_tags_title': 'Ungültige Tags'
+        , 'invalid_tags_msg': 'Ungültige Tags: {tags}'
+        , 'invalid_date_title': 'Ungültiges Datum'
+        , 'invalid_date_msg': 'Datum muss JJMMTT sein'
     }
 }
 


### PR DESCRIPTION
## Summary
- add new translation keys for dialog messages and status text
- use translations for validation dialogs
- translate preview dialog headers
- ensure renamer uses `tr()` for error messages

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PySide6')*

------
https://chatgpt.com/codex/tasks/task_e_6855e99dcda883269a099a38eaf912c2