### PR TITLE
Implement wrap toolbar layout

### DIFF
--- a/mic_renamer/ui/__init__.py
+++ b/mic_renamer/ui/__init__.py
@@ -1,2 +1,6 @@
 """UI components."""
 
+from .flow_layout import FlowLayout
+from .wrap_toolbar import WrapToolBar
+
+__all__ = ["FlowLayout", "WrapToolBar"]

--- a/mic_renamer/ui/flow_layout.py
+++ b/mic_renamer/ui/flow_layout.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+"""A simple flow layout that arranges child widgets horizontally and wraps."""
+
+from PySide6.QtWidgets import QLayout, QWidgetItem, QWidget
+from PySide6.QtCore import QRect, QSize, Qt
+
+
+class FlowLayout(QLayout):
+    """Lay out widgets horizontally and wrap them to new rows when needed."""
+
+    def __init__(self, parent: QWidget | None = None, margin: int = 0, spacing: int | None = None) -> None:
+        super().__init__(parent)
+        self._items: list[QWidgetItem] = []
+        if parent is not None:
+            self.setContentsMargins(margin, margin, margin, margin)
+        if spacing is not None:
+            self.setSpacing(spacing)
+
+    # QLayout API -----------------------------------------------------
+    def addItem(self, item: QWidgetItem) -> None:  # noqa: D401 - Qt override
+        self._items.append(item)
+
+    def count(self) -> int:  # noqa: D401 - Qt override
+        return len(self._items)
+
+    def itemAt(self, index: int) -> QWidgetItem | None:  # noqa: D401 - Qt override
+        if 0 <= index < len(self._items):
+            return self._items[index]
+        return None
+
+    def takeAt(self, index: int) -> QWidgetItem | None:  # noqa: D401 - Qt override
+        if 0 <= index < len(self._items):
+            return self._items.pop(index)
+        return None
+
+    def expandingDirections(self) -> Qt.Orientations:  # noqa: D401 - Qt override
+        return Qt.Orientations(0)
+
+    def hasHeightForWidth(self) -> bool:  # noqa: D401 - Qt override
+        return True
+
+    def heightForWidth(self, width: int) -> int:  # noqa: D401 - Qt override
+        return self._do_layout(QRect(0, 0, width, 0), True)
+
+    def setGeometry(self, rect: QRect) -> None:  # noqa: D401 - Qt override
+        super().setGeometry(rect)
+        self._do_layout(rect, False)
+
+    def sizeHint(self) -> QSize:  # noqa: D401 - Qt override
+        return self.minimumSize()
+
+    def minimumSize(self) -> QSize:  # noqa: D401 - Qt override
+        size = QSize()
+        for item in self._items:
+            size = size.expandedTo(item.minimumSize())
+        left, top, right, bottom = self.getContentsMargins()
+        size += QSize(left + right, top + bottom)
+        return size
+
+    # internal --------------------------------------------------------
+    def _do_layout(self, rect: QRect, test_only: bool) -> int:
+        x = rect.x()
+        y = rect.y()
+        line_height = 0
+
+        left, top, right, bottom = self.getContentsMargins()
+        effective_rect = rect.adjusted(left, top, -right, -bottom)
+
+        for item in self._items:
+            hint = item.sizeHint()
+            space_x = self.spacing()
+            space_y = self.spacing()
+            next_x = x + hint.width() + space_x
+            if next_x - space_x > effective_rect.right() and line_height > 0:
+                x = effective_rect.x()
+                y = y + line_height + space_y
+                next_x = x + hint.width() + space_x
+                line_height = 0
+            if not test_only:
+                item.setGeometry(QRect(x, y, hint.width(), hint.height()))
+            x = next_x
+            line_height = max(line_height, hint.height())
+
+        return y + line_height - rect.y() + top + bottom

--- a/mic_renamer/ui/main_window.py
+++ b/mic_renamer/ui/main_window.py
@@ -2,7 +2,7 @@ import os
 import re
 from PySide6.QtWidgets import (
     QWidget, QHBoxLayout, QVBoxLayout, QSplitter,
-    QPushButton, QSlider, QFileDialog, QMessageBox, QToolBar,
+    QPushButton, QSlider, QFileDialog, QMessageBox,
     QApplication, QLabel, QComboBox,
     QProgressDialog, QDialog, QDialogButtonBox,
     QStyle, QTableWidget, QTableWidgetItem,
@@ -27,6 +27,7 @@ from ..logic.settings import ItemSettings
 from ..logic.renamer import Renamer
 from ..logic.tag_usage import increment_tags
 from ..logic.undo_manager import UndoManager
+from .wrap_toolbar import WrapToolBar
 
 
 ROLE_SETTINGS = Qt.UserRole + 1
@@ -43,7 +44,7 @@ class RenamerApp(QWidget):
 
         main_layout = QVBoxLayout(self)
 
-        self.toolbar = QToolBar()
+        self.toolbar = WrapToolBar()
         self.setup_toolbar()
         main_layout.addWidget(self.toolbar)
 

--- a/mic_renamer/ui/wrap_toolbar.py
+++ b/mic_renamer/ui/wrap_toolbar.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+"""A toolbar widget that wraps its tool buttons using :class:`FlowLayout`."""
+
+from typing import Iterable
+
+from PySide6.QtWidgets import QWidget, QToolButton, QFrame
+from PySide6.QtGui import QAction
+from PySide6.QtCore import Qt
+
+from .flow_layout import FlowLayout
+
+
+class WrapToolBar(QWidget):
+    """Toolbar-like widget that wraps buttons when space is limited."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._layout = FlowLayout(self)
+        self._layout.setContentsMargins(0, 0, 0, 0)
+        self._layout.setSpacing(2)
+        self._buttons: list[QToolButton] = []
+        self._tool_button_style = Qt.ToolButtonIconOnly
+
+    # basic API -------------------------------------------------------
+    def addAction(self, action: QAction) -> QToolButton:  # noqa: D401 - Qt like
+        btn = QToolButton()
+        btn.setDefaultAction(action)
+        btn.setToolButtonStyle(self._tool_button_style)
+        self._layout.addWidget(btn)
+        self._buttons.append(btn)
+        return btn
+
+    def addWidget(self, widget: QWidget) -> None:  # noqa: D401 - Qt like
+        self._layout.addWidget(widget)
+        if isinstance(widget, QToolButton):
+            widget.setToolButtonStyle(self._tool_button_style)
+            self._buttons.append(widget)
+
+    def addSeparator(self) -> None:  # noqa: D401 - Qt like
+        line = QFrame()
+        line.setFrameShape(QFrame.VLine)
+        line.setFrameShadow(QFrame.Sunken)
+        self._layout.addWidget(line)
+
+    def actions(self) -> Iterable[QAction]:  # noqa: D401 - Qt like
+        return [btn.defaultAction() for btn in self._buttons if btn.defaultAction() is not None]
+
+    # style handling --------------------------------------------------
+    def setToolButtonStyle(self, style: Qt.ToolButtonStyle) -> None:  # noqa: D401
+        self._tool_button_style = style
+        for btn in self._buttons:
+            btn.setToolButtonStyle(style)
+
+    def toolButtonStyle(self) -> Qt.ToolButtonStyle:  # noqa: D401
+        return self._tool_button_style


### PR DESCRIPTION
## Summary
- add `FlowLayout` for wrapping widgets
- create `WrapToolBar` using `FlowLayout`
- use `WrapToolBar` in `RenamerApp`
- expose new classes in `ui.__init__`

## Testing
- `pytest tests/test_tag_panel.py -vv -s`
- `pytest tests/test_selection_restore.py -q` *(fails: ModuleNotFoundError: No module named 'mic_renamer')*


------
https://chatgpt.com/codex/tasks/task_e_6855f6c2ffb88326bc1ff9bbdc20d514