### PR TITLE
Enable table sorting with header click

### DIFF
--- a/mic_renamer/ui/panels/file_table.py
+++ b/mic_renamer/ui/panels/file_table.py
@@ -43,6 +43,8 @@ class DragDropTableWidget(QTableWidget):
         header.setSectionResizeMode(4, QHeaderView.ResizeToContents)
         header.setStretchLastSection(True)
         header.sectionDoubleClicked.connect(self.on_header_double_clicked)
+        self.setSortingEnabled(True)
+        self.sortByColumn(1, Qt.AscendingOrder)
         self.setHorizontalScrollMode(QAbstractItemView.ScrollPerPixel)
         self.setAcceptDrops(True)
         self.setSelectionBehavior(QTableWidget.SelectRows)
@@ -245,6 +247,7 @@ class DragDropTableWidget(QTableWidget):
         if self.rowCount() > 0 and not self.selectionModel().hasSelection():
             self.selectRow(0)
         if added:
+            self.sortByColumn(1, Qt.AscendingOrder)
             self.pathsAdded.emit(added)
 
     def sync_check_column(self):

--- a/tests/test_header_sort.py
+++ b/tests/test_header_sort.py
@@ -1,0 +1,36 @@
+import os
+import pytest
+from PySide6.QtWidgets import QApplication
+from PySide6.QtCore import Qt, QPoint
+from PySide6.QtTest import QTest
+
+from mic_renamer.ui.main_window import RenamerApp
+
+
+@pytest.fixture(scope="module")
+def app():
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+def test_header_sorting(app, tmp_path):
+    img1 = tmp_path / "b.jpg"
+    img2 = tmp_path / "a.jpg"
+    img1.write_bytes(b"x")
+    img2.write_bytes(b"y")
+    win = RenamerApp()
+    win.table_widget.add_paths([str(img1), str(img2)])
+    assert win.table_widget.item(0, 1).text() == "a.jpg"
+    assert win.table_widget.item(1, 1).text() == "b.jpg"
+
+    header = win.table_widget.horizontalHeader()
+    x = header.sectionPosition(1) + header.sectionSize(1) // 2
+    pos = QPoint(x, header.height() // 2)
+    QTest.mouseClick(header.viewport(), Qt.LeftButton, pos=pos)
+    app.processEvents()
+
+    assert win.table_widget.item(0, 1).text() == "b.jpg"
+    assert win.table_widget.item(1, 1).text() == "a.jpg"


### PR DESCRIPTION
## Summary
- enable sorting on the drag-drop table widget
- keep column 0 unsorted by default and sort by filename when files are added
- test that clicking a header sorts rows

## Testing
- `pytest tests/test_header_sort.py::test_header_sorting -q`
- `pytest tests/test_selection_restore.py -q`
- `pytest tests/test_suffix_edit.py -q`
- `pytest tests/test_splitter_state.py -q`
- `pytest tests/test_tag_panel.py -q`
- `pytest tests/test_tag_apply.py::test_checkbox_applies_tag -vv`
- `timeout 20 pytest tests/test_tag_apply.py::test_existing_tags_detected -vv` *(fails: ModuleNotFoundError: No module named 'mic_renamer')*


------
https://chatgpt.com/codex/tasks/task_e_6855fed0a2f48326a6ee1680c957d60b