### PR TITLE
Add action to clear suffixes

### DIFF
--- a/mic_renamer/utils/i18n.py
+++ b/mic_renamer/utils/i18n.py
@@ -56,6 +56,7 @@ TRANSLATIONS = {
         'restore_defaults': 'Restore Defaults',
         'reset_tag_usage': 'Reset Tag Usage',
         'remove_selected': 'Remove Selected',
+        'clear_suffix': 'Clear Suffix',
         'config_path_label': 'Configuration folder',
         'default_save_dir_label': 'Default save directory',
         'use_text_menu': 'Text-only toolbar',
@@ -133,6 +134,7 @@ TRANSLATIONS = {
         'restore_defaults': 'Standardeinstellungen wiederherstellen',
         'reset_tag_usage': 'Tag-Nutzung zurücksetzen',
         'remove_selected': 'Auswahl entfernen',
+        'clear_suffix': 'Suffix entfernen',
         'show_tags': 'Tags anzeigen',
         'hide_tags': 'Tags ausblenden'
         , 'current_name': 'Aktueller Name'

--- a/tests/test_clear_suffix_action.py
+++ b/tests/test_clear_suffix_action.py
@@ -1,0 +1,40 @@
+import os
+import pytest
+from PySide6.QtWidgets import QApplication
+from PySide6.QtCore import QItemSelectionModel
+
+from mic_renamer.ui.main_window import RenamerApp, ROLE_SETTINGS
+
+
+@pytest.fixture(scope="module")
+def app():
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+def select_two_rows(table):
+    table.selectRow(0)
+    index = table.model().index(1, 0)
+    table.selectionModel().select(index, QItemSelectionModel.Select | QItemSelectionModel.Rows)
+
+
+def test_clear_selected_suffixes(app, tmp_path):
+    img1 = tmp_path / "one.jpg"
+    img2 = tmp_path / "two.jpg"
+    img1.write_bytes(b"x")
+    img2.write_bytes(b"y")
+    win = RenamerApp()
+    win.table_widget.add_paths([str(img1), str(img2)])
+    win.table_widget.item(0, 4).setText("foo")
+    win.table_widget.item(1, 4).setText("bar")
+    select_two_rows(win.table_widget)
+    win.clear_selected_suffixes()
+    assert win.table_widget.item(0, 4).text() == ""
+    assert win.table_widget.item(1, 4).text() == ""
+    st0 = win.table_widget.item(0, 1).data(ROLE_SETTINGS)
+    st1 = win.table_widget.item(1, 1).data(ROLE_SETTINGS)
+    assert st0.suffix == ""
+    assert st1.suffix == ""


### PR DESCRIPTION
## Summary
- add `clear_suffix` translation key for both languages
- add `Clear Suffix` toolbar action and implementation
- implement `clear_selected_suffixes` to wipe suffix info from selected rows
- test clearing suffixes works for multi-select

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q` *(fails: ImportError libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_685664980a748326a7754f1e06b644f8