### PR TITLE
Fix layout spacing

### DIFF
--- a/mic_renamer/ui/main_window.py
+++ b/mic_renamer/ui/main_window.py
@@ -44,8 +44,11 @@ class RenamerApp(QWidget):
         self.setWindowTitle(tr("app_title"))
 
         main_layout = QVBoxLayout(self)
+        main_layout.setContentsMargins(0, 0, 0, 0)
+        main_layout.setSpacing(2)
 
         self.toolbar = WrapToolBar()
+        self.toolbar.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
         self.setup_toolbar()
         main_layout.addWidget(self.toolbar)
 
@@ -53,7 +56,7 @@ class RenamerApp(QWidget):
 
         # main splitter between preview and table
         self.splitter = QSplitter(Qt.Horizontal)
-        main_layout.addWidget(self.splitter)
+        main_layout.addWidget(self.splitter, 1)
 
         viewer_widget = QWidget()
         viewer_layout = QVBoxLayout(viewer_widget)

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -1,0 +1,30 @@
+import os
+import pytest
+from PySide6.QtWidgets import QApplication, QSizePolicy
+
+from mic_renamer.ui.main_window import RenamerApp
+
+
+@pytest.fixture(scope="module")
+def app():
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+def test_splitter_below_toolbar(app):
+    win = RenamerApp()
+    win.show()
+    app.processEvents()
+    layout = win.layout()
+    margins = layout.contentsMargins()
+    assert (margins.left(), margins.top(), margins.right(), margins.bottom()) == (0, 0, 0, 0)
+    assert layout.spacing() == 2
+    assert layout.itemAt(0).widget() is win.toolbar
+    assert layout.itemAt(1).widget() is win.splitter
+    assert layout.stretch(1) == 1
+    policy = win.toolbar.sizePolicy()
+    assert policy.verticalPolicy() == QSizePolicy.Fixed
+    win.close()


### PR DESCRIPTION
## Summary
- remove excess margins in main layout
- test layout margins
- ensure splitter expands while toolbar stays fixed

## Testing
- `pytest tests/test_layout.py -q`


------
https://chatgpt.com/codex/tasks/task_e_685667d96ab8832699e9db032c43cc00