### PR TITLE
Add configurable import directory

### DIFF
--- a/mic_renamer/config/config_manager.py
+++ b/mic_renamer/config/config_manager.py
@@ -69,6 +69,7 @@ class ConfigManager:
         defaults.setdefault("tag_usage_file", str(Path(get_config_dir()) / "tag_usage.json"))
         # directory used when choosing an alternative save location
         defaults.setdefault("default_save_directory", str(get_config_dir()))
+        defaults.setdefault("default_import_directory", "")
         # migrate legacy setting name
         if "compression_max_size_mb" in data and "compression_max_size_kb" not in data:
             data["compression_max_size_kb"] = float(data.pop("compression_max_size_mb")) * 1024
@@ -116,6 +117,7 @@ class ConfigManager:
         defaults.setdefault("tags_file", str(Path(get_config_dir()) / "tags.json"))
         defaults.setdefault("tag_usage_file", str(Path(get_config_dir()) / "tag_usage.json"))
         defaults.setdefault("default_save_directory", str(get_config_dir()))
+        defaults.setdefault("default_import_directory", "")
         defaults.setdefault("compression_max_size_kb", 2048)
         defaults.setdefault("compression_quality", 95)
         defaults.setdefault("compression_reduce_resolution", True)

--- a/mic_renamer/config/defaults.yaml
+++ b/mic_renamer/config/defaults.yaml
@@ -16,6 +16,7 @@ last_project_number: ""
 tag_panel_visible: false
 toolbar_style: icons
 default_save_directory: ""
+default_import_directory: ""
 compression_max_size_kb: 2048
 compression_quality: 95
 compression_reduce_resolution: true

--- a/mic_renamer/ui/main_window.py
+++ b/mic_renamer/ui/main_window.py
@@ -367,7 +367,11 @@ class RenamerApp(QWidget):
         self.set_status_message(None)
 
     def add_folder_dialog(self):
-        folder = QFileDialog.getExistingDirectory(self, tr("add_folder"))
+        folder = QFileDialog.getExistingDirectory(
+            self,
+            tr("add_folder"),
+            config_manager.get('default_import_directory', '')
+        )
         if folder:
             self.set_status_message(tr("status_loading"))
             entries = os.listdir(folder)

--- a/mic_renamer/ui/settings_dialog.py
+++ b/mic_renamer/ui/settings_dialog.py
@@ -56,6 +56,24 @@ class SettingsDialog(QDialog):
         hl_save.addWidget(btn_browse_save)
         gen_layout.addLayout(hl_save)
 
+        self.chk_import_dir = QCheckBox(tr('use_import_dir'))
+        gen_layout.addWidget(self.chk_import_dir)
+
+        hl_import = QHBoxLayout()
+        hl_import.addWidget(QLabel(tr('default_import_dir_label')))
+        self.edit_import_dir = QLineEdit(self.cfg.get('default_import_directory', ''))
+        self.btn_browse_import = QPushButton('...')
+        self.btn_browse_import.clicked.connect(self.choose_import_dir)
+        hl_import.addWidget(self.edit_import_dir)
+        hl_import.addWidget(self.btn_browse_import)
+        gen_layout.addLayout(hl_import)
+
+        self.chk_import_dir.setChecked(bool(self.cfg.get('default_import_directory')))
+        self.edit_import_dir.setEnabled(self.chk_import_dir.isChecked())
+        self.btn_browse_import.setEnabled(self.chk_import_dir.isChecked())
+        self.chk_import_dir.toggled.connect(self.edit_import_dir.setEnabled)
+        self.chk_import_dir.toggled.connect(self.btn_browse_import.setEnabled)
+
         hl = QHBoxLayout()
         hl.addWidget(QLabel(tr("language_label")))
         self.combo_lang = QComboBox()
@@ -115,6 +133,12 @@ class SettingsDialog(QDialog):
         if dir_path:
             self.edit_save_dir.setText(dir_path)
 
+    def choose_import_dir(self):
+        from PySide6.QtWidgets import QFileDialog
+        dir_path = QFileDialog.getExistingDirectory(self, tr('default_import_dir_label'), self.edit_import_dir.text() or str(config_manager.get('default_import_directory', '')))
+        if dir_path:
+            self.edit_import_dir.setText(dir_path)
+
     def add_tag_row(self):
         row = self.tbl_tags.rowCount()
         self.tbl_tags.insertRow(row)
@@ -128,6 +152,10 @@ class SettingsDialog(QDialog):
         # save language
         self.cfg['language'] = self.combo_lang.currentText()
         self.cfg['default_save_directory'] = self.edit_save_dir.text().strip()
+        if self.chk_import_dir.isChecked():
+            self.cfg['default_import_directory'] = self.edit_import_dir.text().strip()
+        else:
+            self.cfg['default_import_directory'] = ''
         style = 'text' if self.chk_toolbar_text.isChecked() else 'icons'
         self.cfg['toolbar_style'] = style
         config_manager.set('toolbar_style', style)
@@ -169,6 +197,10 @@ class SettingsDialog(QDialog):
         restore_default_tags()
         self.edit_ext.setText(", ".join(self.cfg.get("accepted_extensions", [])))
         self.edit_save_dir.setText(self.cfg.get('default_save_directory', ''))
+        self.edit_import_dir.setText(self.cfg.get('default_import_directory', ''))
+        self.chk_import_dir.setChecked(bool(self.cfg.get('default_import_directory')))
+        self.edit_import_dir.setEnabled(self.chk_import_dir.isChecked())
+        self.btn_browse_import.setEnabled(self.chk_import_dir.isChecked())
         self.chk_toolbar_text.setChecked(
             self.cfg.get("toolbar_style", "icons") == "text"
         )

--- a/mic_renamer/utils/i18n.py
+++ b/mic_renamer/utils/i18n.py
@@ -59,6 +59,8 @@ TRANSLATIONS = {
         'clear_suffix': 'Clear Suffix',
         'config_path_label': 'Configuration folder',
         'default_save_dir_label': 'Default save directory',
+        'default_import_dir_label': 'Default import directory',
+        'use_import_dir': 'Use default import directory',
         'use_text_menu': 'Text-only toolbar',
         'use_original_directory': 'Use current folder?',
         'use_original_directory_msg': 'Save renamed files in their current folder?',
@@ -148,6 +150,8 @@ TRANSLATIONS = {
         , 'undo_done': 'Umbenennungen zurückgesetzt.'
         , 'config_path_label': 'Konfigurationsordner'
         , 'default_save_dir_label': 'Standard-Speicherordner'
+        , 'default_import_dir_label': 'Standard-Importordner'
+        , 'use_import_dir': 'Standard-Importordner verwenden'
         , 'use_text_menu': 'Nur Text in der Werkzeugleiste'
         , 'use_original_directory': 'Aktuellen Ordner verwenden?'
         , 'use_original_directory_msg': 'Umbenannte Dateien im aktuellen Ordner speichern?'


### PR DESCRIPTION
## Summary
- support `default_import_directory` in configuration
- allow setting import directory from SettingsDialog
- pre-select import folder from configuration when adding folders
- localize import directory labels

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_6856ec5a97548326b67c12782432248e