### PR TITLE
Add keyboard editing for table cells

### DIFF
--- a/mic_renamer/ui/panels/file_table.py
+++ b/mic_renamer/ui/panels/file_table.py
@@ -324,3 +324,35 @@ class DragDropTableWidget(QTableWidget):
                     idx.row() for idx in self.selectionModel().selectedRows()
                 ]
         super().mousePressEvent(event)
+
+    def keyPressEvent(self, event):  # noqa: D401
+        """Start editing on keypress and handle Enter navigation."""
+        index = self.currentIndex()
+        edit_cols = {4}
+        if self.mode == "normal":
+            edit_cols.update({2, 3})
+        else:
+            edit_cols.add(2)
+
+        if index.isValid() and index.column() in edit_cols:
+            if event.key() in (Qt.Key_Return, Qt.Key_Enter):
+                row = index.row()
+                col = index.column()
+                super().keyPressEvent(event)
+                if row < self.rowCount() - 1:
+                    self.setCurrentCell(row + 1, col)
+                    self.selectRow(row + 1)
+                return
+            if self.state() != QAbstractItemView.EditingState and event.text():
+                rows = [idx.row() for idx in self.selectionModel().selectedRows()]
+                if len(rows) > 1 and index.row() in rows:
+                    self._selection_before_edit = rows
+                    QTimer.singleShot(0, lambda r=rows: self._restore_selection(r))
+                else:
+                    self._selection_before_edit = rows
+                self.edit(index)
+                editor = QApplication.focusWidget()
+                if editor and editor is not self:
+                    QApplication.sendEvent(editor, event)
+                return
+        super().keyPressEvent(event)


### PR DESCRIPTION
## Summary
- allow editing via keyboard in file table
- move to the next row after pressing Enter while editing

## Testing
- `pytest -q` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_6856f104c80883269d71d255320d461e