### PR TITLE
Add keyboard editing for table cells

### DIFF
--- a/mic_renamer/ui/panels/file_table.py
+++ b/mic_renamer/ui/panels/file_table.py
@@ -332,12 +332,14 @@ class DragDropTableWidget(QTableWidget):
 
         if index.isValid() and index.column() in edit_cols:
             if event.key() in (Qt.Key_Return, Qt.Key_Enter):
-                row = index.row()
+                row_before = index.row()
                 col = index.column()
                 super().keyPressEvent(event)
-                if row < self.rowCount() - 1:
-                    self.setCurrentCell(row + 1, col)
-                    self.selectRow(row + 1)
+                # Qt sometimes moves to the next row automatically
+                if self.currentRow() == row_before and row_before < self.rowCount() - 1:
+                    next_row = row_before + 1
+                    self.setCurrentCell(next_row, col)
+                    self.selectRow(next_row)
                 return
 
             if self.state() != QAbstractItemView.EditingState and event.text():
@@ -348,9 +350,7 @@ class DragDropTableWidget(QTableWidget):
                 else:
                     self._selection_before_edit = rows
                 self.edit(index)
-                editor = QApplication.focusWidget()
-                if editor and editor is not self:
-                    QApplication.sendEvent(editor, event)
+                super().keyPressEvent(event)
                 return
 
         super().keyPressEvent(event)

--- a/mic_renamer/ui/theme.py
+++ b/mic_renamer/ui/theme.py
@@ -27,7 +27,8 @@ def create_dark_palette() -> QPalette:
     palette.setColor(QPalette.ButtonText, Qt.white)
     palette.setColor(QPalette.BrightText, Qt.red)
     palette.setColor(QPalette.Link, BRAND_PRIMARY)
-    palette.setColor(QPalette.Highlight, BRAND_PRIMARY)
+    # use a brighter shade for selected cells
+    palette.setColor(QPalette.Highlight, BRAND_PRIMARY.lighter(190))
     palette.setColor(QPalette.HighlightedText, Qt.black)
     return palette
 

--- a/mic_renamer/ui/theme.py
+++ b/mic_renamer/ui/theme.py
@@ -28,7 +28,7 @@ def create_dark_palette() -> QPalette:
     palette.setColor(QPalette.BrightText, Qt.red)
     palette.setColor(QPalette.Link, BRAND_PRIMARY)
     # use a brighter shade for selected cells
-    palette.setColor(QPalette.Highlight, BRAND_PRIMARY.lighter(190))
+    palette.setColor(QPalette.Highlight, BRAND_PRIMARY.lighter(210))
     palette.setColor(QPalette.HighlightedText, Qt.black)
     return palette
 


### PR DESCRIPTION
## Summary
- allow editing via keyboard in file table
- move to the next row after pressing Enter while editing
- improve highlight color contrast and fix row navigation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'mic_renamer')*


------
https://chatgpt.com/codex/tasks/task_e_6856f104c80883269d71d255320d461e