### PR TITLE
Add tooltips for settings

### DIFF
--- a/mic_renamer/ui/panels/compression_settings.py
+++ b/mic_renamer/ui/panels/compression_settings.py
@@ -26,29 +26,35 @@ class CompressionSettingsPanel(QWidget):
         self.spin_size.setRange(10, 100000)
         self.spin_size.setSuffix(" KB")
         self.spin_size.setValue(float(cfg.get("compression_max_size_kb", 2048)))
+        self.spin_size.setToolTip(tr("max_size_desc"))
         layout.addRow(tr("max_size_label"), self.spin_size)
 
         self.spin_quality = QSpinBox()
         self.spin_quality.setRange(1, 100)
         self.spin_quality.setValue(int(cfg.get("compression_quality", 95)))
+        self.spin_quality.setToolTip(tr("quality_desc"))
         layout.addRow(tr("quality_label"), self.spin_quality)
 
         self.chk_reduce = EnterToggleCheckBox(tr("reduce_resolution_label"))
         self.chk_reduce.setChecked(cfg.get("compression_reduce_resolution", True))
+        self.chk_reduce.setToolTip(tr("reduce_resolution_desc"))
         layout.addRow(self.chk_reduce)
 
         self.chk_resize_only = EnterToggleCheckBox(tr("resize_only_label"))
         self.chk_resize_only.setChecked(cfg.get("compression_resize_only", False))
+        self.chk_resize_only.setToolTip(tr("resize_only_desc"))
         layout.addRow(self.chk_resize_only)
 
         self.spin_max_w = QSpinBox()
         self.spin_max_w.setRange(0, 10000)
         self.spin_max_w.setValue(int(cfg.get("compression_max_width", 0)))
+        self.spin_max_w.setToolTip(tr("max_width_desc"))
         layout.addRow(tr("max_width_label"), self.spin_max_w)
 
         self.spin_max_h = QSpinBox()
         self.spin_max_h.setRange(0, 10000)
         self.spin_max_h.setValue(int(cfg.get("compression_max_height", 0)))
+        self.spin_max_h.setToolTip(tr("max_height_desc"))
         layout.addRow(tr("max_height_label"), self.spin_max_h)
 
         self.btn_reset = QPushButton(tr("restore_defaults"))

--- a/mic_renamer/ui/settings_dialog.py
+++ b/mic_renamer/ui/settings_dialog.py
@@ -41,15 +41,21 @@ class SettingsDialog(QDialog):
         tabs.addTab(general, tr("settings_title"))
         gen_layout = QVBoxLayout(general)
 
-        gen_layout.addWidget(QLabel(f"{tr('config_path_label')}: {config_manager.config_dir}"))
+        lbl_cfg = QLabel(f"{tr('config_path_label')}: {config_manager.config_dir}")
+        lbl_cfg.setToolTip(tr('config_path_desc'))
+        gen_layout.addWidget(lbl_cfg)
 
         gen_layout.addWidget(QLabel(tr("accepted_ext_label")))
         self.edit_ext = QLineEdit(", ".join(self.cfg.get("accepted_extensions", [])))
+        self.edit_ext.setToolTip(tr("accepted_ext_desc"))
         gen_layout.addWidget(self.edit_ext)
 
         hl_save = QHBoxLayout()
-        hl_save.addWidget(QLabel(tr('default_save_dir_label')))
+        lbl_save = QLabel(tr('default_save_dir_label'))
+        lbl_save.setToolTip(tr('default_save_dir_desc'))
+        hl_save.addWidget(lbl_save)
         self.edit_save_dir = QLineEdit(self.cfg.get('default_save_directory', ''))
+        self.edit_save_dir.setToolTip(tr('default_save_dir_desc'))
         btn_browse_save = QPushButton('...')
         btn_browse_save.clicked.connect(self.choose_save_dir)
         hl_save.addWidget(self.edit_save_dir)
@@ -57,11 +63,15 @@ class SettingsDialog(QDialog):
         gen_layout.addLayout(hl_save)
 
         self.chk_import_dir = QCheckBox(tr('use_import_dir'))
+        self.chk_import_dir.setToolTip(tr('use_import_dir_desc'))
         gen_layout.addWidget(self.chk_import_dir)
 
         hl_import = QHBoxLayout()
-        hl_import.addWidget(QLabel(tr('default_import_dir_label')))
+        lbl_import = QLabel(tr('default_import_dir_label'))
+        lbl_import.setToolTip(tr('default_import_dir_desc'))
+        hl_import.addWidget(lbl_import)
         self.edit_import_dir = QLineEdit(self.cfg.get('default_import_directory', ''))
+        self.edit_import_dir.setToolTip(tr('default_import_dir_desc'))
         self.btn_browse_import = QPushButton('...')
         self.btn_browse_import.clicked.connect(self.choose_import_dir)
         hl_import.addWidget(self.edit_import_dir)
@@ -75,9 +85,12 @@ class SettingsDialog(QDialog):
         self.chk_import_dir.toggled.connect(self.btn_browse_import.setEnabled)
 
         hl = QHBoxLayout()
-        hl.addWidget(QLabel(tr("language_label")))
+        lbl_lang = QLabel(tr("language_label"))
+        lbl_lang.setToolTip(tr("language_desc"))
+        hl.addWidget(lbl_lang)
         self.combo_lang = QComboBox()
         self.combo_lang.addItems(["en", "de"])
+        self.combo_lang.setToolTip(tr("language_desc"))
         current_lang = self.cfg.get("language", "en")
         index = self.combo_lang.findText(current_lang)
         if index >= 0:
@@ -86,6 +99,7 @@ class SettingsDialog(QDialog):
         gen_layout.addLayout(hl)
 
         self.chk_toolbar_text = QCheckBox(tr("use_text_menu"))
+        self.chk_toolbar_text.setToolTip(tr("use_text_menu_desc"))
         self.chk_toolbar_text.setChecked(
             self.cfg.get("toolbar_style", "icons") == "text"
         )

--- a/mic_renamer/utils/i18n.py
+++ b/mic_renamer/utils/i18n.py
@@ -32,11 +32,17 @@ TRANSLATIONS = {
         'settings_title': 'Settings',
         'compression_settings': 'Compression',
         'max_size_label': 'Max Size (KB):',
+        'max_size_desc': 'Target maximum file size after compression',
         'quality_label': 'JPEG Quality:',
+        'quality_desc': 'JPEG quality percentage',
         'reduce_resolution_label': 'Reduce resolution if needed',
+        'reduce_resolution_desc': 'Lower image resolution if needed',
         'resize_only_label': 'Resize only',
+        'resize_only_desc': 'Resize images without recompressing',
         'max_width_label': 'Max Width (px):',
+        'max_width_desc': 'Resize images wider than this width (0 = no limit)',
         'max_height_label': 'Max Height (px):',
+        'max_height_desc': 'Resize images taller than this height (0 = no limit)',
         'compression_done': 'Compression finished.',
         'rename_options_title': 'Rename Options',
         'compression_window_title': 'Compression Results',
@@ -51,17 +57,24 @@ TRANSLATIONS = {
         'show_tags': 'Show tags',
         'hide_tags': 'Hide tags',
         'accepted_ext_label': 'Accepted File Extensions (comma separated):',
+        'accepted_ext_desc': 'File types to show in the file browser',
         'language_label': 'Language:',
+        'language_desc': 'Language for interface texts',
         'tags_label': 'Tags',
         'restore_defaults': 'Restore Defaults',
         'reset_tag_usage': 'Reset Tag Usage',
         'remove_selected': 'Remove Selected',
         'clear_suffix': 'Clear Suffix',
         'config_path_label': 'Configuration folder',
+        'config_path_desc': 'Location of the configuration files',
         'default_save_dir_label': 'Default save directory',
+        'default_save_dir_desc': 'Folder used when saving renamed files',
         'default_import_dir_label': 'Default import directory',
+        'default_import_dir_desc': 'Folder used when importing files',
         'use_import_dir': 'Use default import directory',
+        'use_import_dir_desc': 'Automatically open the default import directory',
         'use_text_menu': 'Text-only toolbar',
+        'use_text_menu_desc': 'Show text instead of icons in the toolbar',
         'use_original_directory': 'Use current folder?',
         'use_original_directory_msg': 'Save renamed files in their current folder?',
         'current_name': 'Current Name'
@@ -114,11 +127,17 @@ TRANSLATIONS = {
         'settings_title': 'Einstellungen',
         'compression_settings': 'Kompression',
         'max_size_label': 'Maximale Größe (KB):',
+        'max_size_desc': 'Ziel für maximale Dateigröße nach Komprimierung',
         'quality_label': 'JPEG-Qualität:',
+        'quality_desc': 'JPEG-Qualität in Prozent',
         'reduce_resolution_label': 'Auflösung reduzieren falls nötig',
+        'reduce_resolution_desc': 'Bildauflösung bei Bedarf verringern',
         'resize_only_label': 'Nur Größe anpassen',
+        'resize_only_desc': 'Bilder nur skalieren ohne neue Komprimierung',
         'max_width_label': 'Maximale Breite (px):',
+        'max_width_desc': 'Bilder breiter als diese Pixelzahl verkleinern (0 = kein Limit)',
         'max_height_label': 'Maximale Höhe (px):',
+        'max_height_desc': 'Bilder höher als diese Pixelzahl verkleinern (0 = kein Limit)',
         'compression_done': 'Komprimierung abgeschlossen.',
         'rename_options_title': 'Optionen für Umbenennen',
         'compression_window_title': 'Ergebnis der Komprimierung',
@@ -131,7 +150,9 @@ TRANSLATIONS = {
         'heic_convert_title': 'HEIC umwandeln',
         'heic_convert_msg': 'HEIC-Bilder vor dem Komprimieren in JPEG konvertieren?',
         'accepted_ext_label': 'Erlaubte Dateiendungen (durch Komma getrennt):',
+        'accepted_ext_desc': 'Dateitypen, die im Dateidialog angezeigt werden',
         'language_label': 'Sprache:',
+        'language_desc': 'Sprache der Benutzeroberfläche',
         'tags_label': 'Tags',
         'restore_defaults': 'Standardeinstellungen wiederherstellen',
         'reset_tag_usage': 'Tag-Nutzung zurücksetzen',
@@ -149,10 +170,15 @@ TRANSLATIONS = {
         , 'undo_nothing_msg': 'Keine Umbenennungen zum Rückgängigmachen.'
         , 'undo_done': 'Umbenennungen zurückgesetzt.'
         , 'config_path_label': 'Konfigurationsordner'
+        , 'config_path_desc': 'Speicherort der Konfigurationsdateien'
         , 'default_save_dir_label': 'Standard-Speicherordner'
+        , 'default_save_dir_desc': 'Ordner zum Speichern umbenannter Dateien'
         , 'default_import_dir_label': 'Standard-Importordner'
+        , 'default_import_dir_desc': 'Ordner zum Importieren von Dateien'
         , 'use_import_dir': 'Standard-Importordner verwenden'
+        , 'use_import_dir_desc': 'Standard-Importordner automatisch öffnen'
         , 'use_text_menu': 'Nur Text in der Werkzeugleiste'
+        , 'use_text_menu_desc': 'Nur Text statt Symbole in der Werkzeugleiste'
         , 'use_original_directory': 'Aktuellen Ordner verwenden?'
         , 'use_original_directory_msg': 'Umbenannte Dateien im aktuellen Ordner speichern?'
         , 'mode_normal': 'Normal'


### PR DESCRIPTION
## Summary
- add descriptions for each setting in i18n translations
- show descriptions as tooltips in the Settings dialog
- add tooltips for compression settings controls

## Testing
- `pytest -q` *(fails: ImportError libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_68572c641e9c83268666263b38666389