### PR TITLE
Fix duplicate keyPressEvent logic

### DIFF
--- a/mic_renamer/ui/panels/file_table.py
+++ b/mic_renamer/ui/panels/file_table.py
@@ -354,16 +354,4 @@ class DragDropTableWidget(QTableWidget):
                 return
 
         super().keyPressEvent(event)
-                return
-
-            if self.state() != QAbstractItemView.EditingState and event.text():
-                rows = [idx.row() for idx in self.selectionModel().selectedRows()]
-                if len(rows) > 1 and index.row() in rows:
-                    self._selection_before_edit = rows
-                    QTimer.singleShot(0, lambda r=rows: self._restore_selection(r))
-                else:
-                    self._selection_before_edit = rows
-                self.edit(index)
-                super().keyPressEvent(event)
-                return
 


### PR DESCRIPTION
## Summary
- remove repeated logic in `keyPressEvent` of `DragDropTableWidget`
- call parent `keyPressEvent` once at the end

## Testing
- `ruff check mic_renamer/ui/panels/file_table.py`
- `pytest -q` *(fails: ModuleNotFoundError: pillow_heif)*

------
https://chatgpt.com/codex/tasks/task_e_6857cdc695408326a087a1c370a35dea