### PR TITLE
Add clear icons and toolbar icon size

### DIFF
--- a/mic_renamer/resources/icons/clear.svg
+++ b/mic_renamer/resources/icons/clear.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#009ee0" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="12" r="10"/>
+  <line x1="15" y1="9" x2="9" y2="15"/>
+  <line x1="9" y1="9" x2="15" y2="15"/>
+</svg>

--- a/mic_renamer/resources/icons/suffix-clear.svg
+++ b/mic_renamer/resources/icons/suffix-clear.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#009ee0" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="3" y="3" width="18" height="18" rx="2" ry="2"/>
+  <line x1="9" y1="9" x2="15" y2="15"/>
+  <line x1="15" y1="9" x2="9" y2="15"/>
+</svg>

--- a/mic_renamer/ui/main_window.py
+++ b/mic_renamer/ui/main_window.py
@@ -9,7 +9,7 @@ from PySide6.QtWidgets import (
     QMenu, QToolButton, QSizePolicy, QToolBar,
 )
 from PySide6.QtGui import QColor, QAction, QIcon
-from PySide6.QtCore import Qt, QTimer
+from PySide6.QtCore import Qt, QTimer, QSize
 
 from .. import config_manager
 from ..utils.i18n import tr, set_language
@@ -50,6 +50,7 @@ class RenamerApp(QWidget):
 
         self.toolbar = WrapToolBar()
         self.toolbar.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+        self.toolbar.setIconSize(QSize(24, 24))
         self.setup_toolbar()
         main_layout.addWidget(self.toolbar)
 
@@ -101,6 +102,7 @@ class RenamerApp(QWidget):
         table_layout.setSpacing(2)
 
         self.table_toolbar = QToolBar()
+        self.table_toolbar.setIconSize(QSize(24, 24))
         self.setup_table_toolbar()
         self.apply_toolbar_style(config_manager.get("toolbar_style", "icons"))
         table_layout.addWidget(self.table_toolbar)
@@ -244,13 +246,14 @@ class RenamerApp(QWidget):
         self.toolbar_actions.append(self.act_remove_sel)
         self.toolbar_action_icons.append(icon_remove_sel)
 
-        self.act_clear_suffix = QAction(icon_remove_sel, tr("clear_suffix"), self)
+        icon_clear_suffix = resource_icon("suffix-clear.svg")
+        self.act_clear_suffix = QAction(icon_clear_suffix, tr("clear_suffix"), self)
         self.act_clear_suffix.setToolTip(tr("tip_clear_suffix"))
         self.act_clear_suffix.triggered.connect(self.clear_selected_suffixes)
         self.toolbar_actions.append(self.act_clear_suffix)
-        self.toolbar_action_icons.append(icon_remove_sel)
+        self.toolbar_action_icons.append(icon_clear_suffix)
 
-        icon_clear = resource_icon("trash-2.svg")
+        icon_clear = resource_icon("clear.svg")
         self.act_clear = QAction(icon_clear, tr("clear_list"), self)
         self.act_clear.setToolTip(tr("tip_clear_list"))
         self.act_clear.triggered.connect(self.clear_all)
@@ -277,7 +280,9 @@ class RenamerApp(QWidget):
         """Create toolbar with table-related actions."""
         tb = self.table_toolbar
         tb.addAction(self.act_remove_sel)
+        self.act_clear_suffix.setIcon(resource_icon("suffix-clear.svg"))
         tb.addAction(self.act_clear_suffix)
+        self.act_clear.setIcon(resource_icon("clear.svg"))
         tb.addAction(self.act_clear)
         tb.addSeparator()
         self.combo_mode = QComboBox()

--- a/mic_renamer/ui/wrap_toolbar.py
+++ b/mic_renamer/ui/wrap_toolbar.py
@@ -6,7 +6,7 @@ from typing import Iterable
 
 from PySide6.QtWidgets import QWidget, QToolButton, QFrame
 from PySide6.QtGui import QAction
-from PySide6.QtCore import Qt
+from PySide6.QtCore import Qt, QSize
 
 from .flow_layout import FlowLayout
 
@@ -21,12 +21,14 @@ class WrapToolBar(QWidget):
         self._layout.setSpacing(2)
         self._buttons: list[QToolButton] = []
         self._tool_button_style = Qt.ToolButtonIconOnly
+        self._icon_size = QSize(24, 24)
 
     # basic API -------------------------------------------------------
     def addAction(self, action: QAction) -> QToolButton:  # noqa: D401 - Qt like
         btn = QToolButton()
         btn.setDefaultAction(action)
         btn.setToolButtonStyle(self._tool_button_style)
+        btn.setIconSize(self._icon_size)
         self._layout.addWidget(btn)
         self._buttons.append(btn)
         return btn
@@ -35,6 +37,7 @@ class WrapToolBar(QWidget):
         self._layout.addWidget(widget)
         if isinstance(widget, QToolButton):
             widget.setToolButtonStyle(self._tool_button_style)
+            widget.setIconSize(self._icon_size)
             self._buttons.append(widget)
 
     def addSeparator(self) -> None:  # noqa: D401 - Qt like
@@ -54,3 +57,13 @@ class WrapToolBar(QWidget):
 
     def toolButtonStyle(self) -> Qt.ToolButtonStyle:  # noqa: D401
         return self._tool_button_style
+
+    def setIconSize(self, size: QSize) -> None:
+        """Set icon size for all buttons."""
+        self._icon_size = size
+        for btn in self._buttons:
+            btn.setIconSize(size)
+
+    def iconSize(self) -> QSize:
+        """Return current icon size."""
+        return self._icon_size


### PR DESCRIPTION
## Summary
- add new icons for clearing suffixes and the file list
- use new icons in the main and table toolbars
- set fixed icon size for both toolbars
- support icon size in `WrapToolBar`

## Testing
- `pytest -q` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_68580044df4883268f13f0ad55849a62