### PR TITLE
Add debounce for table selection

### DIFF
--- a/tests/test_tag_apply.py
+++ b/tests/test_tag_apply.py
@@ -2,6 +2,7 @@ import os
 import pytest
 from PySide6.QtWidgets import QApplication
 from PySide6.QtCore import Qt
+from PySide6.QtTest import QTest
 
 from mic_renamer.ui.main_window import RenamerApp, ROLE_SETTINGS
 
@@ -51,5 +52,6 @@ def test_existing_tags_detected(app, monkeypatch, tmp_path):
     settings = item0.data(ROLE_SETTINGS)
     assert settings.tags == {"A", "B"}
     win.on_table_selection_changed()
+    QTest.qWait(150)
     assert win.tag_panel.checkbox_map["A"].checkState() == Qt.Checked
     assert win.tag_panel.checkbox_map["B"].checkState() == Qt.Checked


### PR DESCRIPTION
## Summary
- add a QTimer in RenamerApp to debounce selection updates
- update heavy selection work to a new `_apply_selection_change` method
- adjust tests for delayed selection processing

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ImportError libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_68581997cacc83268141201673b1340f