### PR TITLE
Add threaded image preview loader

### DIFF
--- a/mic_renamer/ui/panels/image_preview.py
+++ b/mic_renamer/ui/panels/image_preview.py
@@ -57,9 +57,20 @@ class ImageViewer(QGraphicsView):
             self.reset_transform()
             return
         pix = QPixmap.fromImage(img)
-        self.current_pixmap = pix
+        self.set_pixmap(pix)
+
+    def set_pixmap(self, pixmap: QPixmap) -> None:
+        if pixmap.isNull():
+            self.scene().clear()
+            self.pixmap_item = None
+            self.current_pixmap = None
+            self._zoom_pct = 100
+            self._rotation = 0
+            self.reset_transform()
+            return
+        self.current_pixmap = pixmap
         self.scene().clear()
-        self.pixmap_item = self.scene().addPixmap(pix)
+        self.pixmap_item = self.scene().addPixmap(pixmap)
         self.pixmap_item.setTransformationMode(Qt.SmoothTransformation)
         self.scene().setSceneRect(self.pixmap_item.boundingRect())
         self._rotation = 0

--- a/mic_renamer/ui/panels/media_viewer.py
+++ b/mic_renamer/ui/panels/media_viewer.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from PySide6.QtCore import Qt, QUrl
+from PySide6.QtGui import QPixmap
 from PySide6.QtWidgets import (
     QWidget,
     QStackedLayout,
@@ -111,6 +112,11 @@ class MediaViewer(QWidget):
         else:
             self.image_viewer.load_image("")
             self.stack.setCurrentWidget(self.image_viewer)
+
+    def show_pixmap(self, pixmap: QPixmap) -> None:
+        """Display a preloaded pixmap."""
+        self.image_viewer.set_pixmap(pixmap)
+        self.stack.setCurrentWidget(self.image_viewer)
 
     # expose image viewer controls
     @property


### PR DESCRIPTION
## Summary
- add `PreviewLoader` worker for loading images off the main thread
- allow `ImageViewer` and `MediaViewer` to display a preloaded pixmap
- load previews asynchronously in `RenamerApp`
- cleanly stop preview thread when closing the app

## Testing
- `pytest -q` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_6858228a6648832685c3d3558dc88c24