### PR TITLE
Fix compression rotation and remember dialog size

### DIFF
--- a/mic_renamer/logic/heic_converter.py
+++ b/mic_renamer/logic/heic_converter.py
@@ -20,12 +20,16 @@ def convert_to_jpeg(path: str) -> str:
         return path
     try:
         img = Image.open(src)
+        exif_data = img.info.get("exif")
     except Exception:
         return path
     img = img.convert("RGB")
     dest = src.with_suffix(".jpg")
     try:
-        img.save(dest, format="JPEG")
+        if exif_data:
+            img.save(dest, format="JPEG", exif=exif_data)
+        else:
+            img.save(dest, format="JPEG")
     except Exception:
         img.close()
         return path
@@ -48,17 +52,24 @@ def convert_heic(path: str) -> str:
         return path
     try:
         img = Image.open(src)
+        exif_data = img.info.get("exif")
     except Exception:
         return path
 
     has_alpha = "A" in img.getbands()
     if has_alpha:
         dest = src.with_suffix(".png")
-        img.save(dest, format="PNG")
+        if exif_data:
+            img.save(dest, format="PNG", exif=exif_data)
+        else:
+            img.save(dest, format="PNG")
     else:
         img = img.convert("RGB")
         dest = src.with_suffix(".jpg")
-        img.save(dest, format="JPEG")
+        if exif_data:
+            img.save(dest, format="JPEG", exif=exif_data)
+        else:
+            img.save(dest, format="JPEG")
     img.close()
     try:
         src.unlink()

--- a/mic_renamer/logic/image_compressor.py
+++ b/mic_renamer/logic/image_compressor.py
@@ -57,6 +57,7 @@ class ImageCompressor:
             return out_path, orig_size, 0
 
         img = Image.open(path)
+        exif_data = img.info.get("exif")
         fmt = img.format
         if convert_heic and path.lower().endswith(".heic"):
             fmt = "JPEG"
@@ -79,11 +80,15 @@ class ImageCompressor:
         if fmt == "JPEG" and not self.resize_only:
             save_kwargs["quality"] = self.quality
 
+        if exif_data:
+            save_kwargs["exif"] = exif_data
         img.save(out_path, format=fmt, **save_kwargs)
         new_size = os.path.getsize(out_path)
         if self.reduce_resolution and new_size > self.max_size:
             while new_size > self.max_size and img.width > 100 and img.height > 100:
                 img = img.resize((int(img.width * 0.9), int(img.height * 0.9)), Image.LANCZOS)
+                if exif_data:
+                    save_kwargs["exif"] = exif_data
                 img.save(out_path, format=fmt, **save_kwargs)
                 new_size = os.path.getsize(out_path)
         img.close()

--- a/mic_renamer/ui/main_window.py
+++ b/mic_renamer/ui/main_window.py
@@ -862,7 +862,12 @@ class RenamerApp(QWidget):
             )
             convert_heic = reply == QMessageBox.Yes
         from .compression_dialog import CompressionDialog
-        dlg = CompressionDialog(paths, convert_heic, parent=self)
+        dlg = CompressionDialog(
+            paths,
+            convert_heic,
+            parent=self,
+            state_manager=self.state_manager,
+        )
         if dlg.exec() == QDialog.Accepted:
             for row, new_path, size_bytes, compressed_bytes in dlg.final_results:
                 item0 = self.table_widget.item(row, 1)


### PR DESCRIPTION
## Summary
- preserve EXIF data so orientation remains unchanged after compression
- keep EXIF when converting images to JPEG/PNG
- allow `CompressionDialog` to restore/save its size via `StateManager`
- pass the state manager from `MainWindow` when opening the compression preview

## Testing
- `pytest -q` *(fails: ImportError: libEGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_6858107913f88326a38f6e0261d58323