### PR TITLE
Fix sorting during rename

### DIFF
--- a/mic_renamer/ui/main_window.py
+++ b/mic_renamer/ui/main_window.py
@@ -536,7 +536,6 @@ class RenamerApp(QWidget):
                     cell_suffix.setToolTip(settings.suffix)
             self.update_row_background(row, settings)
         self.table_widget.sync_check_column()
-        QTimer.singleShot(0, self._enable_sorting)
 
     def on_tag_toggled(self, code: str, state: int) -> None:
         """Apply tag changes from the tag panel to all selected rows immediately.
@@ -1075,6 +1074,7 @@ class RenamerApp(QWidget):
         self.update_status()
     def execute_rename_with_progress(self, table_mapping, compress: bool = False):
         self.set_status_message(tr("renaming_files"))
+        self.table_widget.setSortingEnabled(False)
         total = len(table_mapping)
         progress = QProgressDialog(
             tr("renaming_files"),
@@ -1176,6 +1176,7 @@ class RenamerApp(QWidget):
                     increment_tags(used_tags)
                     self.tag_panel.rebuild()
             self.set_status_message(None)
+            self._enable_sorting()
 
         worker.finished.connect(on_finished)
         thread.start()

--- a/tests/test_rename_sorted.py
+++ b/tests/test_rename_sorted.py
@@ -1,0 +1,76 @@
+import os
+import pytest
+from PySide6.QtWidgets import QApplication, QMessageBox
+from PySide6.QtCore import Qt, QThread
+
+from mic_renamer.ui.main_window import RenamerApp
+
+
+@pytest.fixture(scope="module")
+def app():
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    a = QApplication.instance()
+    if a is None:
+        a = QApplication([])
+    return a
+
+
+class DummyProgress:
+    """Minimal progress dialog replacement for tests."""
+    def __init__(self, *args, **kwargs):
+        self.canceled = type("Signal", (), {"connect": lambda *a, **k: None})()
+
+    def setWindowModality(self, *_):
+        pass
+
+    def setMinimumDuration(self, *_):
+        pass
+
+    def setValue(self, *_):
+        pass
+
+    def close(self):
+        pass
+
+    def wasCanceled(self):
+        return False
+
+
+def test_rename_updates_sorted_rows(app, monkeypatch, tmp_path):
+    img_a = tmp_path / "a.jpg"
+    img_b = tmp_path / "b.jpg"
+    img_a.write_bytes(b"x")
+    img_b.write_bytes(b"y")
+
+    win = RenamerApp()
+    win.table_widget.add_paths([str(img_a), str(img_b)])
+    # sort descending by filename
+    win.table_widget.sortByColumn(1, Qt.DescendingOrder)
+    app.processEvents()
+
+    new_c = tmp_path / "c.jpg"
+    new_d = tmp_path / "d.jpg"
+
+    table_mapping = [
+        (0, str(img_b), new_c.name, str(new_c)),
+        (1, str(img_a), new_d.name, str(new_d)),
+    ]
+
+    monkeypatch.setattr("mic_renamer.ui.main_window.QProgressDialog", DummyProgress)
+    monkeypatch.setattr(QThread, "start", lambda self: self.started.emit())
+    monkeypatch.setattr(QThread, "quit", lambda self: None)
+    monkeypatch.setattr(QThread, "wait", lambda self: None)
+    monkeypatch.setattr(QMessageBox, "warning", lambda *a, **k: None)
+    monkeypatch.setattr(QMessageBox, "information", lambda *a, **k: None)
+
+    win.execute_rename_with_progress(table_mapping)
+    app.processEvents()
+
+    # sorting should still be descending
+    assert win.table_widget.horizontalHeader().sortIndicatorOrder() == Qt.DescendingOrder
+    assert win.table_widget.item(0, 1).text() == "d.jpg"
+    assert win.table_widget.item(1, 1).text() == "c.jpg"
+    assert os.path.exists(new_c)
+    assert os.path.exists(new_d)
+    win.close()
+


### PR DESCRIPTION
## Summary
- disable table sorting before rename tasks run
- re-enable sorting after rename results are processed
- drop immediate sorting in `save_current_item_settings`
- add a unit test for renaming while sorted

## Testing
- `pip install PySide6 appdirs PyYAML Pillow pillow-heif` *(fails: could not access network)*
- `apt-get update` *(fails: could not access network)*
- `apt-get install -y libegl1` *(fails: could not access network)*
- `pytest -q` *(fails: could not run tests)*

------
https://chatgpt.com/codex/tasks/task_e_685826b66d6c8326bbf32f593ce13914