### PR TITLE
Fix suffix extraction with numeric index

### DIFF
--- a/mic_renamer/logic/tag_service.py
+++ b/mic_renamer/logic/tag_service.py
@@ -57,6 +57,10 @@ def extract_suffix_from_name(name: str, valid_tags: Iterable[str]) -> str:
         return ""
     candidate = tokens[-1]
     codes = set(valid_tags)
+    if candidate.isdigit():
+        if len(tokens) < 2:
+            return ""
+        candidate = tokens[-2]
     if candidate in codes:
         return ""
     if re.fullmatch(r"\d{6}", candidate):

--- a/tests/test_suffix_extract.py
+++ b/tests/test_suffix_extract.py
@@ -47,3 +47,14 @@ def test_suffix_not_extracted_for_numeric_or_tag(app, monkeypatch, tmp_path):
     settings1 = item1.data(ROLE_SETTINGS)
     assert settings0.suffix == ""
     assert settings1.suffix == ""
+
+
+def test_suffix_before_numeric_index(app, monkeypatch, tmp_path):
+    tags = {"A": "Alpha"}
+    monkeypatch.setattr("mic_renamer.logic.tag_loader.load_tags", lambda: tags)
+    monkeypatch.setattr("mic_renamer.ui.panels.file_table.load_tags", lambda: tags)
+    img = tmp_path / "C123456_A_240101_note_001.jpg"
+    img.write_bytes(b"x")
+    win = RenamerApp()
+    win.table_widget.add_paths([str(img)])
+    assert win.table_widget.item(0, 4).text() == "note"


### PR DESCRIPTION
## Summary
- handle numeric index while extracting suffixes
- test suffix detection when a numeric token is present

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q` *(fails: ImportError: libEGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68582ab69be48326b3f68b33773ec9ef