### PR TITLE
Refine renamer filename scheme

### DIFF
--- a/mic_renamer/logic/settings.py
+++ b/mic_renamer/logic/settings.py
@@ -56,8 +56,6 @@ class ItemSettings:
         date_str = self._date_str(config)
         parts = [project] + ordered_tags + [date_str]
         base = config.separator.join(parts)
-        if self.suffix:
-            base += f"{config.separator}{self.suffix}"
         return base
 
     def build_new_name(
@@ -69,10 +67,13 @@ class ItemSettings:
         include_index: bool = True,
     ) -> str:
         base = self.build_base_name(project, ordered_tags, config)
+        name = base
         if include_index:
-            base += f"{config.separator}{index:0{config.index_padding}d}"
+            name += f"{config.separator}{index:0{config.index_padding}d}"
+        if self.suffix:
+            name += f"{config.separator}{self.suffix}"
         ext = os.path.splitext(self.original_path)[1]
-        return base + ext
+        return name + ext
 
 
 # backward compatibility

--- a/tests/test_pa_mat_mode.py
+++ b/tests/test_pa_mat_mode.py
@@ -37,4 +37,4 @@ def test_pa_mat_used_in_name(tmp_path):
     mapping = renamer.build_mapping()
     assert len(mapping) == 1
     _, _, new = mapping[0]
-    assert "_pa_mat7" in os.path.basename(new)
+    assert "_PA_MAT7" in os.path.basename(new)


### PR DESCRIPTION
## Summary
- update base name generation to drop suffix
- place numeric index before suffix when building new names
- adjust PA_MAT naming test

## Testing
- `PYTHONPATH=. pytest tests/test_pa_mat_mode.py -vv -k test_pa_mat_used_in_name`

------
https://chatgpt.com/codex/tasks/task_e_68582bd739688326a7bdeb776b68b3a5