### PR TITLE
Implement multi-token suffix parsing

### DIFF
--- a/tests/test_suffix_extract.py
+++ b/tests/test_suffix_extract.py
@@ -58,3 +58,17 @@ def test_suffix_before_numeric_index(app, monkeypatch, tmp_path):
     win = RenamerApp()
     win.table_widget.add_paths([str(img)])
     assert win.table_widget.item(0, 4).text() == "note"
+
+
+def test_multi_token_suffix(app, monkeypatch, tmp_path):
+    tags = {"A": "Alpha"}
+    monkeypatch.setattr("mic_renamer.logic.tag_loader.load_tags", lambda: tags)
+    monkeypatch.setattr("mic_renamer.ui.panels.file_table.load_tags", lambda: tags)
+    img = tmp_path / "proj_A_230101_long_extra_001.jpg"
+    img.write_bytes(b"x")
+    win = RenamerApp()
+    win.table_widget.add_paths([str(img)])
+    assert win.table_widget.item(0, 4).text() == "long_extra"
+    item0 = win.table_widget.item(0, 1)
+    settings = item0.data(ROLE_SETTINGS)
+    assert settings.suffix == "long_extra"


### PR DESCRIPTION
## Summary
- handle multi-token suffix extraction after the first YYMMDD date
- return suffix unless it is a single known tag
- test multi-token suffix support

## Testing
- `pytest tests/test_suffix_extract.py::test_multi_token_suffix -q` *(fails: ImportError: libEGL.so.1 cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_685834e318f48326872d5072f3e318e8