### PR TITLE
Stop video playback when closing window

### DIFF
--- a/mic_renamer/ui/main_window.py
+++ b/mic_renamer/ui/main_window.py
@@ -1205,6 +1205,8 @@ class RenamerApp(QWidget):
         )
 
     def closeEvent(self, event):
+        # ensure any playing video is stopped to release multimedia resources
+        self.image_viewer.video_player.player.stop()
         if self._preview_loader:
             self._preview_loader.stop()
         if self._preview_thread:


### PR DESCRIPTION
## Summary
- stop the QMediaPlayer when the main window closes

## Testing
- `pytest -q` *(fails: ImportError: libEGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_6858413552a88326a2fdd00f1f94b529