### PR TITLE
Improve compression dialog thread cleanup

### DIFF
--- a/mic_renamer/ui/compression_dialog.py
+++ b/mic_renamer/ui/compression_dialog.py
@@ -162,6 +162,11 @@ class CompressionDialog(QDialog):
         super().accept()
 
     def reject(self) -> None:
+        self._worker.stop()
+        self._thread.quit()
+        self._thread.wait()
+        self._worker.deleteLater()
+        self._thread.deleteLater()
         self._tmpdir.cleanup()
         super().reject()
 


### PR DESCRIPTION
## Summary
- stop the compression worker if dialog rejected
- close the worker thread and delete both objects

## Testing
- `pytest --maxfail=1 -q` *(fails: test_rename_updates_sorted_rows)*

------
https://chatgpt.com/codex/tasks/task_e_6858425d9f0c8326ac4c35720acf45d6