### PR TITLE
Fix worker connections in compression dialog

### DIFF
--- a/mic_renamer/ui/compression_dialog.py
+++ b/mic_renamer/ui/compression_dialog.py
@@ -102,8 +102,8 @@ class CompressionDialog(QDialog):
         worker.moveToThread(self._thread)
         self._worker = worker
         self._thread.started.connect(worker.run)
-        worker.progress.connect(self._on_progress)
-        worker.finished.connect(self._on_finished)
+        worker.progress.connect(self._on_progress, Qt.QueuedConnection)
+        worker.finished.connect(self._on_finished, Qt.QueuedConnection)
         self.progress.canceled.connect(worker.stop)
         self._thread.start()
 


### PR DESCRIPTION
## Summary
- ensure compression progress/finish signals use queued connections

## Testing
- `pytest -q` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_6858764a38e88326b8e574cfa8a54682