### PR TITLE
Add missing config defaults

### DIFF
--- a/mic_renamer/config/config_manager.py
+++ b/mic_renamer/config/config_manager.py
@@ -25,12 +25,14 @@ last_project_number: ""
 tag_panel_visible: false
 toolbar_style: icons
 default_save_directory: ""
+default_import_directory: ""
 compression_max_size_kb: 2048
 compression_quality: 95
 compression_reduce_resolution: true
 compression_resize_only: false
 compression_max_width: 0
 compression_max_height: 0
+compress_after_rename: false
 """
 import yaml
 


### PR DESCRIPTION
## Summary
- include `default_import_directory` and `compress_after_rename` in `DEFAULTS_YAML`

## Testing
- `pytest -q` *(fails: No module named 'PySide6')*
- `pip install -q -r requirements.txt` *(fails: operation cancelled due to network issues)*

------
https://chatgpt.com/codex/tasks/task_e_68587ab584608326b87bb75efa8185ac