### PR TITLE
Fix rename thread shutdown

### DIFF
--- a/mic_renamer/ui/main_window.py
+++ b/mic_renamer/ui/main_window.py
@@ -1230,7 +1230,8 @@ class RenamerApp(QWidget):
             if self._rename_worker:
                 self._rename_worker.stop()
             self._rename_thread.quit()
-            self._rename_thread.wait(2000)
+            # wait indefinitely for the rename thread to finish
+            self._rename_thread.wait()
             self._rename_thread = None
             self._rename_worker = None
         if self.state_manager:


### PR DESCRIPTION
## Summary
- update closeEvent to wait indefinitely on the rename thread

## Testing
- `pytest -q` *(fails: ImportError libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_68588e8467e88326a588f53ba58cc843