### PR TITLE
Handle rename worker lifecycle

### DIFF
--- a/mic_renamer/ui/compression_dialog.py
+++ b/mic_renamer/ui/compression_dialog.py
@@ -173,6 +173,12 @@ class CompressionDialog(QDialog):
         super().reject()
 
     def closeEvent(self, event):
+        self._worker.stop()
+        if self._thread.isRunning():
+            self._thread.quit()
+            self._thread.wait()
+        self._worker.deleteLater()
+        self._tmpdir.cleanup()
         if self.state_manager:
             self.state_manager.set("compression_width", self.width())
             self.state_manager.set("compression_height", self.height())

--- a/mic_renamer/ui/main_window.py
+++ b/mic_renamer/ui/main_window.py
@@ -48,6 +48,7 @@ class RenamerApp(QWidget):
         self._preview_thread: QThread | None = None
         self._preview_loader: PreviewLoader | None = None
         self._rename_thread: QThread | None = None
+        self._rename_worker: Worker | None = None
         self.setWindowTitle(tr("app_title"))
 
         main_layout = QVBoxLayout(self)
@@ -1136,20 +1137,22 @@ class RenamerApp(QWidget):
                 result["error"] = str(e)
             return result
 
-        worker = Worker(task, table_mapping)
+        self._rename_worker = Worker(task, table_mapping)
         self._rename_thread = QThread()
-        worker.moveToThread(self._rename_thread)
-        self._rename_thread.started.connect(worker.run)
-        worker.progress.connect(
+        self._rename_worker.moveToThread(self._rename_thread)
+        self._rename_thread.started.connect(self._rename_worker.run)
+        self._rename_worker.progress.connect(
             lambda d, _t, _p: progress.setValue(d), Qt.QueuedConnection
         )
-        progress.canceled.connect(worker.stop)
-        worker.finished.connect(self._rename_thread.quit)
+        progress.canceled.connect(self._rename_worker.stop)
+        self._rename_worker.finished.connect(self._rename_thread.quit)
         self._rename_thread.finished.connect(self._rename_thread.deleteLater)
 
         def on_finished(results):
             progress.close()
-            worker.deleteLater()
+            if self._rename_worker:
+                self._rename_worker.deleteLater()
+            self._rename_worker = None
             self._rename_thread = None
             used_tags = []
             done = len(results)
@@ -1190,7 +1193,7 @@ class RenamerApp(QWidget):
             self.set_status_message(None)
             self._enable_sorting()
 
-        worker.finished.connect(on_finished, Qt.QueuedConnection)
+        self._rename_worker.finished.connect(on_finished, Qt.QueuedConnection)
         self._rename_thread.start()
 
     def update_status(self) -> None:
@@ -1224,9 +1227,12 @@ class RenamerApp(QWidget):
                 self._preview_loader = None
             self._preview_thread = None
         if self._rename_thread and self._rename_thread.isRunning():
+            if self._rename_worker:
+                self._rename_worker.stop()
             self._rename_thread.quit()
             self._rename_thread.wait(2000)
             self._rename_thread = None
+            self._rename_worker = None
         if self.state_manager:
             self.state_manager.set("width", self.width())
             self.state_manager.set("height", self.height())


### PR DESCRIPTION
## Summary
- track rename worker object in the RenamerApp UI
- stop rename worker on close
- reset references once renaming completes
- ensure compression dialog thread is cleaned up on close

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: `libEGL.so.1` missing)*

------
https://chatgpt.com/codex/tasks/task_e_68588964404c83268f219e0498085836