### PR TITLE
Fix thread teardown and remove dead code

### DIFF
--- a/mic_renamer/logic/renamer.py
+++ b/mic_renamer/logic/renamer.py
@@ -2,13 +2,9 @@
 
 import os
 from collections import defaultdict
-from PySide6.QtWidgets import QMessageBox
-
-from ..utils.i18n import tr
 
 from .settings import ItemSettings, RenameConfig
 from ..utils.file_utils import ensure_unique_name
-from .tag_usage import increment_tags
 
 class Renamer:
     def __init__(self, project: str, items: list[ItemSettings], config: RenameConfig | None = None,
@@ -74,24 +70,3 @@ class Renamer:
                 mapping.append((item, item.original_path, unique))
 
         return mapping
-
-    def execute_rename(self, mapping: list[tuple[ItemSettings, str, str]]) -> list[tuple[str, str, Exception]]:
-        """
-        Rename files according to mapping.
-        Returns a list of errors as tuples (orig_path, new_path, exception).
-        """
-        used_tags: list[str] = []
-        errors: list[tuple[str, str, Exception]] = []
-        for item, orig, new in mapping:
-            try:
-                orig_abs = os.path.abspath(orig)
-                new_abs = os.path.abspath(new)
-                if orig_abs != new_abs:
-                    os.rename(orig, new)
-                    item.original_path = new
-                    used_tags.extend(item.tags)
-            except Exception as e:
-                errors.append((orig, new, e))
-        if used_tags and self.mode == "normal":
-            increment_tags(used_tags)
-        return errors


### PR DESCRIPTION
## Summary
- remove unused execute_rename function and clean imports
- consolidate closeEvent in main window and wire worker cleanup
- connect cross-thread signals with Qt.QueuedConnection and auto-delete workers

## Testing
- `python -m py_compile mic_renamer/ui/main_window.py mic_renamer/ui/compression_dialog.py mic_renamer/logic/renamer.py`
- `pytest -q` *(fails: ImportError: libEGL.so.1 not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859d324db588326864d2f81e94da97d