### PR TITLE
Improve compression dialog thread cleanup

### DIFF
--- a/mic_renamer/ui/compression_dialog.py
+++ b/mic_renamer/ui/compression_dialog.py
@@ -107,6 +107,7 @@ class CompressionDialog(QDialog):
         worker.finished.connect(self._on_finished, Qt.QueuedConnection)
         worker.finished.connect(self._thread.quit, Qt.QueuedConnection)
         self._thread.finished.connect(self._thread.deleteLater, Qt.QueuedConnection)
+        self._thread.finished.connect(self._on_thread_finished, Qt.QueuedConnection)
         worker.finished.connect(worker.deleteLater, Qt.QueuedConnection)
         self.progress.canceled.connect(worker.stop, Qt.QueuedConnection)
         self._thread.start()
@@ -150,6 +151,19 @@ class CompressionDialog(QDialog):
         if 0 <= row < len(self._paths):
             self.viewer.load_path(self._paths[row])
 
+    def _on_thread_finished(self) -> None:
+        """Reset worker and thread references when the thread ends."""
+        self._thread = None
+        self._worker = None
+
+    def _cleanup_thread(self) -> None:
+        """Stop and wait for the worker thread if it is still running."""
+        if self._thread and self._thread.isRunning():
+            if self._worker:
+                self._worker.stop()
+            self._thread.quit()
+            self._thread.wait()
+
     def accept(self) -> None:
         for row, orig, preview, old_size, new_size in self.results:
             final_path = orig
@@ -158,28 +172,23 @@ class CompressionDialog(QDialog):
                 os.remove(orig)
             shutil.move(preview, final_path)
             self.final_results.append((row, final_path, old_size, new_size))
-        if self._thread.isRunning():
-            self._thread.quit()
-            self._thread.wait()
+        self._cleanup_thread()
         self._tmpdir.cleanup()
         self.progress.close()
         super().accept()
 
     def reject(self) -> None:
         self._worker.stop()
-        if self._thread.isRunning():
-            self._thread.quit()
-            self._thread.wait()
+        self._cleanup_thread()
         self._tmpdir.cleanup()
         self.progress.close()
         super().reject()
 
     def closeEvent(self, event):
         self._worker.stop()
-        if self._thread.isRunning():
-            self._thread.quit()
-            self._thread.wait()
+        self._cleanup_thread()
         self._tmpdir.cleanup()
+        self.progress.close()
         if self.state_manager:
             self.state_manager.set("compression_width", self.width())
             self.state_manager.set("compression_height", self.height())


### PR DESCRIPTION
## Summary
- clean up worker thread references when compression completes
- consolidate thread shutdown logic via `_cleanup_thread`
- ensure progress dialog closes on `closeEvent`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PySide6')*

------
https://chatgpt.com/codex/tasks/task_e_685bbf4d64988326b413a95c83228174